### PR TITLE
Almost commuting

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -12,7 +12,7 @@ Library srk
   Path: srk/src
   FindlibName: srk
   Pack: true
-  Modules:  SrkUtil, Log, DisjointSet, Memo, FeatureTree, QQ, ZZ, Syntax, Interval, Smt, SrkZ3, Ring, Linear, Polynomial, ExpPolynomial, Interpretation, SrkApron, Polyhedron, SrkSimplify, Abstract, Nonlinear, CoordinateSystem, Wedge, Vas, Vass, Quantifier, Iteration, SolvablePolynomial, LinearSemiautomaton, Transition, BigO, Pathexpr, WeightedGraph, TransitionSystem
+  Modules:  SrkUtil, Log, DisjointSet, Memo, FeatureTree, QQ, ZZ, Syntax, Interval, Smt, SrkZ3, Ring, Linear, Polynomial, ExpPolynomial, Interpretation, SrkApron, Polyhedron, SrkSimplify, Abstract, Nonlinear, CoordinateSystem, Wedge, Vas, Vass, Quantifier, Iteration, SolvablePolynomial, LinearSemiautomaton, AlmostCommuting, Transition, BigO, Pathexpr, WeightedGraph, TransitionSystem
   BuildDepends:     batteries, ppx_deriving, ppx_deriving.show, ppx_deriving.ord, ppx_deriving.eq, gmp, camlidl, apron, Z3, ocrs, ntl, ocamlgraph
   XMETADescription: Symbolic Reasoning Kit
 

--- a/_tags
+++ b/_tags
@@ -1,5 +1,5 @@
 # OASIS_START
-# DO NOT EDIT (digest: 4837f6bfb55a20ca5d0e7cc74502a48a)
+# DO NOT EDIT (digest: b851584f6662a9f90a0f9b3b708ef631)
 # Ignore VCS directories, you can use the same kind of rule outside
 # OASIS_START/STOP if you want to exclude directories that contains
 # useless stuff for the build process
@@ -45,6 +45,7 @@ true: annot, bin_annot
 "srk/src/iteration.cmx": for-pack(Srk)
 "srk/src/solvablePolynomial.cmx": for-pack(Srk)
 "srk/src/linearSemiautomaton.cmx": for-pack(Srk)
+"srk/src/almostCommuting.cmx": for-pack(Srk)
 "srk/src/transition.cmx": for-pack(Srk)
 "srk/src/bigO.cmx": for-pack(Srk)
 "srk/src/pathexpr.cmx": for-pack(Srk)

--- a/srk/_oasis
+++ b/srk/_oasis
@@ -12,7 +12,7 @@ Library srk
   Path:             src
   FindlibName:      srk
   Pack:             true
-  Modules:  SrkUtil, Log, DisjointSet, Memo, FeatureTree, QQ, ZZ, Syntax, Interval, Smt, SrkZ3, Ring, Linear, Polynomial, ExpPolynomial, Interpretation, SrkApron, Polyhedron, SrkSimplify, Abstract, Nonlinear, CoordinateSystem, Wedge, Vas, Vass, Quantifier, Iteration, SolvablePolynomial, LinearSemiautomaton, Transition, BigO, Pathexpr, WeightedGraph, TransitionSystem
+  Modules:  SrkUtil, Log, DisjointSet, Memo, FeatureTree, QQ, ZZ, Syntax, Interval, Smt, SrkZ3, Ring, Linear, Polynomial, ExpPolynomial, Interpretation, SrkApron, Polyhedron, SrkSimplify, Abstract, Nonlinear, CoordinateSystem, Wedge, Vas, Vass, Quantifier, Iteration, SolvablePolynomial, LinearSemiautomaton, AlmostCommuting, Transition, BigO, Pathexpr, WeightedGraph, TransitionSystem
   BuildDepends:     batteries, ppx_deriving, ppx_deriving.show, ppx_deriving.ord, ppx_deriving.eq, gmp, camlidl, apron, Z3, ocrs, ntl, ocamlgraph
   XMETADescription: Symbolic Reasoning Kit
 

--- a/srk/_tags
+++ b/srk/_tags
@@ -1,5 +1,5 @@
 # OASIS_START
-# DO NOT EDIT (digest: b0cdfd30b1f07cadd937b7e8981df75a)
+# DO NOT EDIT (digest: f014c98cd3b6ceed9e82f17d95ea5f90)
 # Ignore VCS directories, you can use the same kind of rule outside
 # OASIS_START/STOP if you want to exclude directories that contains
 # useless stuff for the build process
@@ -45,6 +45,7 @@ true: annot, bin_annot
 "src/iteration.cmx": for-pack(Srk)
 "src/solvablePolynomial.cmx": for-pack(Srk)
 "src/linearSemiautomaton.cmx": for-pack(Srk)
+"src/almostCommuting.cmx": for-pack(Srk)
 "src/transition.cmx": for-pack(Srk)
 "src/bigO.cmx": for-pack(Srk)
 "src/pathexpr.cmx": for-pack(Srk)

--- a/srk/src/almostCommuting.ml
+++ b/srk/src/almostCommuting.ml
@@ -84,7 +84,16 @@ module PhasedSegment = struct
         Array.map
           (fun (k, m) ->
             if k == Reset then
-              max_lds ~zero_rows:true mS (QQMatrix.mul mT m)
+              let mC, mD = pushout (QQMatrix.mul mT m) mS in
+              (* pushout TA S returns C,D such that CTA = DS. We then take the
+                 rowspace intersection of the matrices CT for all A, and iterate
+                 with T' = \bigcap CT. A fixpoint should be reached after two
+                 iterations, i.e. we have rsp(T') = rsp(T). If the fixpoint is
+                 reached, then there exists a C' s.t. C'CT = T. We use C' to
+                 perform a change of basis in order to get TA = C'DS. *)
+              match divide_right mT (QQMatrix.mul mC mT) with
+              | Some mC' -> mC, (QQMatrix.mul mC' mD)
+              | None     -> mC, mD
             else if k == Commute then
               max_lds mT (QQMatrix.mul mT m)
             else

--- a/srk/src/almostCommuting.ml
+++ b/srk/src/almostCommuting.ml
@@ -1,0 +1,21 @@
+open Linear
+open Printf
+
+type kind = Commute | Reset | Ignore
+
+type phased_segment = {
+   sim1 : QQMatrix.t;
+   sim2 : QQMatrix.t;
+   phase1 : QQMatrix.t array;
+   phase2 : (kind * QQMatrix.t) array
+}
+
+type phased_segmentation = phased_segment list
+
+
+let commuting_space mA mB =
+  let dims = SrkUtil.Int.Set.elements (QQMatrix.row_set mA) in
+  let mAB = QQMatrix.mul mA mB in
+  let mBA = QQMatrix.mul mB mA in
+  let mC = QQMatrix.add mAB (QQMatrix.scalar_mul (QQ.negate QQ.one) mBA) in
+  nullspace mC dims

--- a/srk/src/almostCommuting.ml
+++ b/srk/src/almostCommuting.ml
@@ -97,7 +97,7 @@ module PhasedSegment = struct
             else if k == Commute then
               max_lds mT (QQMatrix.mul mT m)
             else
-              mT, m)
+              (QQMatrix.identity dims), m)
           pairs
       in
       let ls = maxldss mT in

--- a/srk/src/almostCommuting.ml
+++ b/srk/src/almostCommuting.ml
@@ -22,29 +22,27 @@ let commuting_space mA mB =
   let mC = QQMatrix.add mAB (QQMatrix.scalar_mul (QQ.negate QQ.one) mBA) in
   nullspace (QQMatrix.transpose mC) dims
 
-let intersect_rowspaces matrices =
-  if Array.length matrices == 0 then
-    raise (Invalid_argument "list of matrices should not be empty")
-  else
-    Array.fold_left 
-      (fun mA mB -> 
-        let (mC, _) = intersect_rowspace mA mB in
-        QQMatrix.mul mC mA)
-      (Array.get matrices 0)
-      matrices
+let intersect_rowspaces matrices dims =
+  Array.fold_left 
+    (fun mA mB -> 
+      let (mC, _) = intersect_rowspace mA mB in
+      QQMatrix.mul mC mA)
+    (QQMatrix.identity dims)
+    matrices
 
 let vspace_equal mA mB =
   VS.equal (VS.of_matrix mA) (VS.of_matrix mB)
 
-let commuting_segment matrices =
+let commuting_segment matrices dims =
   let pairs = BatArray.cartesian_product matrices matrices in
   let cspaces = Array.map (fun (mA, mB) -> VS.matrix_of (commuting_space mA mB)) pairs in
-  let mS = intersect_rowspaces cspaces in
+  let mS = intersect_rowspaces cspaces dims in
   let rec fix mS =
     let maxlds = Array.map (fun mat -> max_lds mS (QQMatrix.mul mS mat)) matrices in
     let sims, matr = BatArray.split maxlds in
     let mSS = intersect_rowspaces 
                 (Array.map (fun m -> QQMatrix.mul m mS) sims)
+                dims
     in
     if vspace_equal mS mSS then
       mS, matr
@@ -53,11 +51,11 @@ let commuting_segment matrices =
   in
   fix mS
 
-let iter_all = Seq.map (fun (_, m) -> m)
+let iter_all = Array.map (fun (_, m) -> m)
 
-let iter_reset = Seq.filter_map (fun (k, m) -> if k == Reset then Some m else None)
+let iter_reset = BatArray.filter_map (fun (k, m) -> if k == Reset then Some m else None)
 
-let iter_commute = Seq.filter_map (fun (k, m) -> if k == Commute then Some m else None)
+let iter_commute = BatArray.filter_map (fun (k, m) -> if k == Commute then Some m else None)
 
 
 module PhasedSegment = struct
@@ -80,33 +78,41 @@ module PhasedSegment = struct
       q.phase2
 
   let make pairs =
-    let mS, phase1 = commuting_segment (Array.of_seq (iter_all (Array.to_seq pairs))) in
-    let mT, _ = commuting_segment (Array.of_seq (iter_commute (Array.to_seq pairs))) in
-    let rec fix mT =
-      let ls_maxlds = Array.map
-        (fun (k, m) ->
-          if k == Reset then
-            max_lds ~zero_rows:true mS (QQMatrix.mul mT m)
-          else if k == Commute then
-            max_lds mT (QQMatrix.mul mT m)
-          else
-            mT, m
-          )
-        pairs
-      in
-      let mTT = intersect_rowspaces
-                  (Array.map (fun (m, _) -> QQMatrix.mul m mT) ls_maxlds)
-      in
-      if vspace_equal mT mTT then
-        let phase2 = Array.mapi
-                      (fun i (_, m) -> let k, _ = Array.get pairs i in (k, m))
-                      ls_maxlds
+    if Array.length pairs == 0 then
+      raise (Invalid_argument "Array of matrices should not be empty")
+    else
+      let _, mA = Array.get pairs 0 in
+      let dims = SrkUtil.Int.Set.elements (QQMatrix.column_set mA) in
+      let mS, phase1 = commuting_segment (iter_all pairs) dims in
+      let mT, _ = commuting_segment (iter_commute pairs) dims in
+      let rec fix mT =
+        let ls_maxlds = Array.map
+          (fun (k, m) ->
+            if k == Reset then
+              max_lds ~zero_rows:true mS (QQMatrix.mul mT m)
+            else if k == Commute then
+              max_lds mT (QQMatrix.mul mT m)
+            else
+              mT, m
+            )
+          pairs
         in
-        { sim1 = mS;
-          sim2 = mTT;
-          phase1 = phase1;
-          phase2 = phase2 }
-      else
-        fix mTT
-    in
-    fix mT
+        let mTT = intersect_rowspaces
+                    (Array.map (fun (m, _) -> QQMatrix.mul m mT) ls_maxlds)
+                    dims
+        in
+        if vspace_equal mT mTT then
+          let phase2 = Array.mapi
+                        (fun i (_, m) -> let k, _ = Array.get pairs i in (k, m))
+                        ls_maxlds
+          in
+          { sim1 = mS;
+            sim2 = mTT;
+            phase1 = phase1;
+            phase2 = phase2 }
+        else
+          fix mTT
+      in
+      fix mT
+
+end

--- a/srk/src/almostCommuting.ml
+++ b/srk/src/almostCommuting.ml
@@ -28,8 +28,6 @@ let intersect_rowspaces matrices =
   else
     Array.fold_left 
       (fun mA mB -> 
-                  (fun mA mB -> 
-      (fun mA mB -> 
         let (mC, _) = intersect_rowspace mA mB in
         QQMatrix.mul mC mA)
       (Array.get matrices 0)
@@ -66,13 +64,14 @@ let mk_phased_segment pairs =
   let mT, _ = commuting_segment (Array.of_seq (iter_commute (Array.to_seq pairs))) in
   let rec fix mT =
     let ls_maxlds = Array.map 
-      (fun (k, m) -> 
+      (fun (k, m) ->
         if k == Reset then
-          max_lds mS (QQMatrix.mul mT m)
+          max_lds ~zero_rows:true mS (QQMatrix.mul mT m)
         else if k == Commute then
           max_lds mT (QQMatrix.mul mT m)
         else
-          mT, m)
+          mT, m
+        )
       pairs
     in
     let mTT = intersect_rowspaces 

--- a/srk/src/almostCommuting.ml
+++ b/srk/src/almostCommuting.ml
@@ -13,7 +13,6 @@ type phased_segment = {
 
 type phased_segmentation = phased_segment list
 
-
 let commuting_space mA mB =
   let dims = SrkUtil.Int.Set.elements (QQMatrix.row_set mA) in
   let mAB = QQMatrix.mul mA mB in
@@ -50,12 +49,9 @@ let commuting_segment matrices dims =
   in
   fix mS
 
-let iter_all = Array.map (fun (_, m) -> m)
-
-let iter_reset = BatArray.filter_map (fun (k, m) -> if k == Reset then Some m else None)
-
+let iter_all     = Array.map (fun (_, m) -> m)
+let iter_reset   = BatArray.filter_map (fun (k, m) -> if k == Reset then Some m else None)
 let iter_commute = BatArray.filter_map (fun (k, m) -> if k == Commute then Some m else None)
-
 
 module PhasedSegment = struct
 
@@ -92,8 +88,7 @@ module PhasedSegment = struct
             else if k == Commute then
               max_lds mT (QQMatrix.mul mT m)
             else
-              mT, m
-            )
+              mT, m)
           pairs
         in
         let mTT = intersect_rowspaces
@@ -102,8 +97,8 @@ module PhasedSegment = struct
         in
         if rowspace_equal mT mTT then
           let phase2 = Array.mapi
-                        (fun i (_, m) -> let k, _ = Array.get pairs i in (k, m))
-                        ls_maxlds
+                         (fun i (_, m) -> let k, _ = Array.get pairs i in (k, m))
+                         ls_maxlds
           in
           { sim1 = mS;
             sim2 = mTT;
@@ -124,9 +119,8 @@ module PhasedSegmentation = struct
     let len = Array.length matrices in
     let products = BatList.n_cartesian_product (BatList.make len [Commute; Reset]) in
     let partitions = BatList.map 
-                      (fun p -> 
-                        Array.map2 (fun x y -> x, y) (Array.of_list p) matrices) 
-                      products
+                       (fun p -> Array.map2 (fun x y -> x, y) (Array.of_list p) matrices) 
+                       products
     in
     BatList.map PhasedSegment.make partitions
 

--- a/srk/src/almostCommuting.ml
+++ b/srk/src/almostCommuting.ml
@@ -29,7 +29,7 @@ let intersect_rowspaces matrices dims =
     (QQMatrix.identity dims)
     matrices
 
-let vspace_equal mA mB =
+let rowspace_equal mA mB =
   VS.equal (VS.of_matrix mA) (VS.of_matrix mB)
 
 let commuting_segment matrices dims =
@@ -43,7 +43,7 @@ let commuting_segment matrices dims =
                 (Array.map (fun m -> QQMatrix.mul m mS) sims)
                 dims
     in
-    if vspace_equal mS mSS then
+    if rowspace_equal mS mSS then
       mS, matr
     else
       fix mSS
@@ -100,7 +100,7 @@ module PhasedSegment = struct
                     (Array.map (fun (m, _) -> QQMatrix.mul m mT) ls_maxlds)
                     dims
         in
-        if vspace_equal mT mTT then
+        if rowspace_equal mT mTT then
           let phase2 = Array.mapi
                         (fun i (_, m) -> let k, _ = Array.get pairs i in (k, m))
                         ls_maxlds

--- a/srk/src/almostCommuting.ml
+++ b/srk/src/almostCommuting.ml
@@ -1,13 +1,15 @@
 open Linear
 open Printf
 
+module VS = QQVectorSpace
+
 type kind = Commute | Reset | Ignore
 
 type phased_segment = {
-   sim1 : QQMatrix.t;
-   sim2 : QQMatrix.t;
-   phase1 : QQMatrix.t array;
-   phase2 : (kind * QQMatrix.t) array
+  sim1 : QQMatrix.t;
+  sim2 : QQMatrix.t;
+  phase1 : QQMatrix.t array;
+  phase2 : (kind * QQMatrix.t) array
 }
 
 type phased_segmentation = phased_segment list
@@ -18,4 +20,35 @@ let commuting_space mA mB =
   let mAB = QQMatrix.mul mA mB in
   let mBA = QQMatrix.mul mB mA in
   let mC = QQMatrix.add mAB (QQMatrix.scalar_mul (QQ.negate QQ.one) mBA) in
-  nullspace mC dims
+  nullspace (QQMatrix.transpose mC) dims
+
+let intersect_rowspaces matrices =
+  match matrices with
+  | [] -> raise (Invalid_argument "list of matrices should not be empty")
+  | [m] -> m
+  | m :: tail -> List.fold_left 
+                  (fun mA mB -> 
+                    let (mC, _) = intersect_rowspace mA mB in
+                    QQMatrix.mul mC mA)
+                  m
+                  tail
+
+let vspace_equal mA mB =
+  VS.equal (VS.of_matrix mA) (VS.of_matrix mB)
+
+let commuting_segment matrices =
+  let pairs = BatList.cartesian_product matrices matrices in
+  let cspaces = List.map (fun (mA, mB) -> VS.matrix_of (commuting_space mA mB)) pairs in
+  let mS = intersect_rowspaces cspaces in
+  let rec fix mS matrices =
+    let maxlds = List.map (fun mat -> max_lds mS (QQMatrix.mul mS mat)) matrices in
+    let sims, matr = List.split maxlds in
+    let mSS = intersect_rowspaces 
+                (List.map (fun m -> QQMatrix.mul m mS) sims)
+    in
+    if vspace_equal mS mSS then
+      mS, matr
+    else
+      fix mSS matrices
+  in
+  fix mS matrices

--- a/srk/src/almostCommuting.ml
+++ b/srk/src/almostCommuting.ml
@@ -135,12 +135,13 @@ module PhasedSegmentation = struct
     let dim = VS.dimension vU in
     VS.equal vU (VS.standard_basis dim)
 
-  let rec best_almost_commuting matrices =
+  let best_almost_commuting matrices =
     let segmentation = make_naive matrices in
-    if almost_commutes segmentation then
-      segmentation
-    else
-      let mC = VS.matrix_of (almost_commuting_space segmentation) in
-      best_almost_commuting (Array.map (fun m -> QQMatrix.mul mC m) matrices)
+    let mC = VS.matrix_of (almost_commuting_space segmentation) in
+    mC, (Array.map (fun m -> 
+                      match divide_right (QQMatrix.mul mC m) mC with
+                      | Some mM -> mM
+                      | None -> assert false)
+                   matrices)
 
 end

--- a/srk/src/almostCommuting.ml
+++ b/srk/src/almostCommuting.ml
@@ -15,27 +15,6 @@ type phased_segment = {
 type phased_segmentation = phased_segment list
 
 
-module PhasedSegment = struct
-
-  type t = phased_segment
-
-  (* TODO: find proper representation *)
-  let show p = QQMatrix.show p.sim1
-
-  let equal p q =
-    QQMatrix.equal p.sim1 q.sim1 &&
-    QQMatrix.equal p.sim2 q.sim2 &&
-    BatArray.for_all2
-      QQMatrix.equal
-      p.phase1
-      q.phase1 &&
-    BatArray.for_all2
-      (fun (k1, m1) (k2, m2) -> k1 == k2 && QQMatrix.equal m1 m2)
-      p.phase2
-      q.phase2
-
-end
-
 let commuting_space mA mB =
   let dims = SrkUtil.Int.Set.elements (QQMatrix.row_set mA) in
   let mAB = QQMatrix.mul mA mB in
@@ -80,34 +59,54 @@ let iter_reset = Seq.filter_map (fun (k, m) -> if k == Reset then Some m else No
 
 let iter_commute = Seq.filter_map (fun (k, m) -> if k == Commute then Some m else None)
 
-let mk_phased_segment pairs =
-  let mS, phase1 = commuting_segment (Array.of_seq (iter_all (Array.to_seq pairs))) in
-  let mT, _ = commuting_segment (Array.of_seq (iter_commute (Array.to_seq pairs))) in
-  let rec fix mT =
-    let ls_maxlds = Array.map 
-      (fun (k, m) ->
-        if k == Reset then
-          max_lds ~zero_rows:true mS (QQMatrix.mul mT m)
-        else if k == Commute then
-          max_lds mT (QQMatrix.mul mT m)
-        else
-          mT, m
-        )
-      pairs
-    in
-    let mTT = intersect_rowspaces 
-                (Array.map (fun (m, _) -> QQMatrix.mul m mT) ls_maxlds)
-    in
-    if vspace_equal mT mTT then
-      let phase2 = Array.mapi
-                     (fun i (_, m) -> let k, _ = Array.get pairs i in (k, m))
-                     ls_maxlds
+
+module PhasedSegment = struct
+
+  type t = phased_segment
+
+  (* TODO: find proper representation *)
+  let show p = QQMatrix.show p.sim1
+
+  let equal p q =
+    QQMatrix.equal p.sim1 q.sim1 &&
+    QQMatrix.equal p.sim2 q.sim2 &&
+    BatArray.for_all2
+      QQMatrix.equal
+      p.phase1
+      q.phase1 &&
+    BatArray.for_all2
+      (fun (k1, m1) (k2, m2) -> k1 == k2 && QQMatrix.equal m1 m2)
+      p.phase2
+      q.phase2
+
+  let make pairs =
+    let mS, phase1 = commuting_segment (Array.of_seq (iter_all (Array.to_seq pairs))) in
+    let mT, _ = commuting_segment (Array.of_seq (iter_commute (Array.to_seq pairs))) in
+    let rec fix mT =
+      let ls_maxlds = Array.map
+        (fun (k, m) ->
+          if k == Reset then
+            max_lds ~zero_rows:true mS (QQMatrix.mul mT m)
+          else if k == Commute then
+            max_lds mT (QQMatrix.mul mT m)
+          else
+            mT, m
+          )
+        pairs
       in
-      { sim1 = mS;
-        sim2 = mTT;
-        phase1 = phase1;
-        phase2 = phase2 }
-    else
-      fix mTT
-  in
-  fix mT
+      let mTT = intersect_rowspaces
+                  (Array.map (fun (m, _) -> QQMatrix.mul m mT) ls_maxlds)
+      in
+      if vspace_equal mT mTT then
+        let phase2 = Array.mapi
+                      (fun i (_, m) -> let k, _ = Array.get pairs i in (k, m))
+                      ls_maxlds
+        in
+        { sim1 = mS;
+          sim2 = mTT;
+          phase1 = phase1;
+          phase2 = phase2 }
+      else
+        fix mTT
+    in
+    fix mT

--- a/srk/src/almostCommuting.ml
+++ b/srk/src/almostCommuting.ml
@@ -15,6 +15,27 @@ type phased_segment = {
 type phased_segmentation = phased_segment list
 
 
+module PhasedSegment = struct
+
+  type t = phased_segment
+
+  (* TODO: find proper representation *)
+  let show p = QQMatrix.show p.sim1
+
+  let equal p q =
+    QQMatrix.equal p.sim1 q.sim1 &&
+    QQMatrix.equal p.sim2 q.sim2 &&
+    BatArray.for_all2
+      QQMatrix.equal
+      p.phase1
+      q.phase1 &&
+    BatArray.for_all2
+      (fun (k1, m1) (k2, m2) -> k1 == k2 && QQMatrix.equal m1 m2)
+      p.phase2
+      q.phase2
+
+end
+
 let commuting_space mA mB =
   let dims = SrkUtil.Int.Set.elements (QQMatrix.row_set mA) in
   let mAB = QQMatrix.mul mA mB in

--- a/srk/src/almostCommuting.mli
+++ b/srk/src/almostCommuting.mli
@@ -1,7 +1,7 @@
 open Linear
 
 val commuting_space : QQMatrix.t -> QQMatrix.t -> QQVectorSpace.t
-val commuting_segment : QQMatrix.t list -> (QQMatrix.t * QQMatrix.t list)
+val commuting_segment : QQMatrix.t array -> (QQMatrix.t * QQMatrix.t array)
 
 type kind = Commute | Reset | Ignore
 
@@ -17,3 +17,5 @@ type phased_segment = {
 }
 
 type phased_segmentation = phased_segment list
+
+val mk_phased_segment : (kind * QQMatrix.t) array -> phased_segment

--- a/srk/src/almostCommuting.mli
+++ b/srk/src/almostCommuting.mli
@@ -10,10 +10,10 @@ type phased_segment = {
    sim2 : QQMatrix.t;                 (* Simulation for phase 2 (all non-reset matrices commute) *)
    phase1 : QQMatrix.t array;         (* Image of each transition under the phase 1 simulation *)
    phase2 : (kind * QQMatrix.t) array (* Each transition i is either of kind Commute, in which case
-                                         phase2.(i) is the image of transition i under the phase 1
+                                         phase2.(i) is the image of transition i under the phase 2
                                          simulation, or of kind Reset, in which case phase2.(i) gives
-                                         a representation of transition i as a transformation from the phase 1
-                                         space to the phase 2 space *)
+                                         a representation of transition i as a transformation from the 
+                                         phase 1 space to the phase 2 space *)
 }
 
 module PhasedSegment : sig

--- a/srk/src/almostCommuting.mli
+++ b/srk/src/almostCommuting.mli
@@ -21,8 +21,8 @@ module PhasedSegment : sig
 
    val show : t -> string
    val equal : t -> t -> bool
+
+   val make : (kind * QQMatrix.t) array -> t
 end
 
 type phased_segmentation = phased_segment list
-
-val mk_phased_segment : (kind * QQMatrix.t) array -> phased_segment

--- a/srk/src/almostCommuting.mli
+++ b/srk/src/almostCommuting.mli
@@ -16,6 +16,13 @@ type phased_segment = {
                                          space to the phase 2 space *)
 }
 
+module PhasedSegment : sig
+   type t = phased_segment
+
+   val show : t -> string
+   val equal : t -> t -> bool
+end
+
 type phased_segmentation = phased_segment list
 
 val mk_phased_segment : (kind * QQMatrix.t) array -> phased_segment

--- a/srk/src/almostCommuting.mli
+++ b/srk/src/almostCommuting.mli
@@ -1,6 +1,7 @@
 open Linear
 
 val commuting_space : QQMatrix.t -> QQMatrix.t -> QQVectorSpace.t
+val commuting_segment : QQMatrix.t list -> (QQMatrix.t * QQMatrix.t list)
 
 type kind = Commute | Reset | Ignore
 

--- a/srk/src/almostCommuting.mli
+++ b/srk/src/almostCommuting.mli
@@ -22,7 +22,22 @@ module PhasedSegment : sig
    val show : t -> string
    val equal : t -> t -> bool
 
+   (** Computes the best phased segment for the given partition of matrices *)
    val make : (kind * QQMatrix.t) array -> t
 end
 
-type phased_segmentation = phased_segment list
+module PhasedSegmentation : sig
+   type t = phased_segment list
+
+   (** Computes a phased segmentation for the given matrices by exhaustively exploring all partitions *)
+   val make_naive : QQMatrix.t array -> t
+
+   (** Returns the vector space where the given segmentation almost commutes *)
+   val almost_commuting_space : t -> QQVectorSpace.t
+
+   (** Returns whether the given phased segmentation almost commutes or not *)
+   val almost_commutes : t -> bool
+
+   (** Computes the best almost commuting abstraction for the given LTS *)
+   val best_almost_commuting : QQMatrix.t array -> t
+end

--- a/srk/src/almostCommuting.mli
+++ b/srk/src/almostCommuting.mli
@@ -1,0 +1,18 @@
+open Linear
+
+val commuting_space : QQMatrix.t -> QQMatrix.t -> QQVectorSpace.t
+
+type kind = Commute | Reset | Ignore
+
+type phased_segment = {
+   sim1 : QQMatrix.t;                 (* Simulation for phase 1 (all matrices commute) *)
+   sim2 : QQMatrix.t;                 (* Simulation for phase 2 (all non-reset matrices commute) *)
+   phase1 : QQMatrix.t array;         (* Image of each transition under the phase 1 simulation *)
+   phase2 : (kind * QQMatrix.t) array (* Each transition i is either of kind Commute, in which case
+                                         phase2.(i) is the image of transition i under the phase 1
+                                         simulation, or of kind Reset, in which case phase2.(i) gives
+                                         a representation of transition i as a transformation from the phase 1
+                                         space to the phase 2 space *)
+}
+
+type phased_segmentation = phased_segment list

--- a/srk/src/almostCommuting.mli
+++ b/srk/src/almostCommuting.mli
@@ -39,5 +39,5 @@ module PhasedSegmentation : sig
    val almost_commutes : t -> bool
 
    (** Computes the best almost commuting abstraction for the given LTS *)
-   val best_almost_commuting : QQMatrix.t array -> t
+   val best_almost_commuting : QQMatrix.t array -> (QQMatrix.t * QQMatrix.t array)
 end

--- a/srk/src/almostCommuting.mli
+++ b/srk/src/almostCommuting.mli
@@ -1,7 +1,7 @@
 open Linear
 
 val commuting_space : QQMatrix.t -> QQMatrix.t -> QQVectorSpace.t
-val commuting_segment : QQMatrix.t array -> (QQMatrix.t * QQMatrix.t array)
+val commuting_segment : QQMatrix.t array -> int list -> (QQMatrix.t * QQMatrix.t array)
 
 type kind = Commute | Reset | Ignore
 

--- a/srk/src/linear.ml
+++ b/srk/src/linear.ml
@@ -571,6 +571,8 @@ module QQVectorSpace = struct
 
   let of_matrix mM = BatList.of_enum (QQMatrix.rowsi mM /@ snd)
 
+  let show vU = QQMatrix.show (matrix_of vU)
+
   let intersect vU vV =
     let (mU, mV) = (matrix_of vU, matrix_of vV) in
     let (mC, _) = intersect_rowspace mU mV in

--- a/srk/src/linear.ml
+++ b/srk/src/linear.ml
@@ -382,7 +382,7 @@ let max_rowspace_projection a b =
       | None -> ()));
   !c
 
-let max_lds mA mB =
+let max_lds ?zero_rows:(zero_rows=false) mA mB =
   (* We have a system of the form Ax' = Bx, we need one of the form Ax' =
      B'Ax.  If we can factor B = B'A, we're done.  Otherwise, we compute an
      m-by-n matrix T' with m < n, and continue iterating with the system T'Ax'
@@ -425,26 +425,29 @@ let max_lds mA mB =
       (SrkUtil.Int.Set.union (QQMatrix.row_set mA) (QQMatrix.row_set mB))
   in
   let (mT, mM) = fix mA mB (QQMatrix.identity dims) in
-  (* Remove coordinates corresponding to zero rows of T*A *)
-  let mTA = QQMatrix.mul mT mA in
-  let mTA_rows = QQMatrix.row_set mTA in
-  BatEnum.foldi (fun i row (mT', mM') ->
-      let mT' =
-        QQMatrix.add_row i (QQMatrix.row row mT) mT'
-      in
-      let mM' =
-        let mM_row = QQMatrix.row row mM in
-        let rowi =
-          BatEnum.foldi (fun j col v ->
-              QQVector.add_term (QQVector.coeff col mM_row) j v)
-            QQVector.zero
-            (SrkUtil.Int.Set.enum mTA_rows)
+  if zero_rows then
+    mT, mM
+  else
+    (* Remove coordinates corresponding to zero rows of T*A *)
+    let mTA = QQMatrix.mul mT mA in
+    let mTA_rows = QQMatrix.row_set mTA in
+    BatEnum.foldi (fun i row (mT', mM') ->
+        let mT' =
+          QQMatrix.add_row i (QQMatrix.row row mT) mT'
         in
-        QQMatrix.add_row i rowi mM'
-      in
-      (mT', mM'))
-    (QQMatrix.zero, QQMatrix.zero)
-    (SrkUtil.Int.Set.enum mTA_rows)
+        let mM' =
+          let mM_row = QQMatrix.row row mM in
+          let rowi =
+            BatEnum.foldi (fun j col v ->
+                QQVector.add_term (QQVector.coeff col mM_row) j v)
+              QQVector.zero
+              (SrkUtil.Int.Set.enum mTA_rows)
+          in
+          QQMatrix.add_row i rowi mM'
+        in
+        (mT', mM'))
+      (QQMatrix.zero, QQMatrix.zero)
+      (SrkUtil.Int.Set.enum mTA_rows)
 
 let rational_spectral_decomposition mA dims =
   let mAt = QQMatrix.transpose mA in

--- a/srk/src/linear.mli
+++ b/srk/src/linear.mli
@@ -129,6 +129,8 @@ module QQVectorSpace : sig
 
   val equal : t -> t -> bool
 
+  val show : t -> string
+
   (** [subspace a b] checks whether [a] is a subspace of [b] *)
   val subspace : t -> t -> bool
 

--- a/srk/src/linear.mli
+++ b/srk/src/linear.mli
@@ -93,7 +93,7 @@ val divide_left : QQMatrix.t -> QQMatrix.t -> QQMatrix.t option
     greatest linear dynamical system that approximates [Ax' = Bx], and [T] is
     the linear transformation into the linear dynamical system.  That is, [TB
     = MTA], and the rowspace of [TA] is maximal. *)
-val max_lds : QQMatrix.t -> QQMatrix.t -> QQMatrix.t * QQMatrix.t
+val max_lds : ?zero_rows:bool -> QQMatrix.t -> QQMatrix.t -> QQMatrix.t * QQMatrix.t
 
 (** Given a matrix [A], find a pair of matrices [(M,T)] such that [MA = TM],
     [T] is lower-triangular, and the rowspace of [MA] is maximal. *)

--- a/srk/src/linear.mli
+++ b/srk/src/linear.mli
@@ -93,7 +93,7 @@ val divide_left : QQMatrix.t -> QQMatrix.t -> QQMatrix.t option
     greatest linear dynamical system that approximates [Ax' = Bx], and [T] is
     the linear transformation into the linear dynamical system.  That is, [TB
     = MTA], and the rowspace of [TA] is maximal. *)
-val max_lds : ?zero_rows:bool -> QQMatrix.t -> QQMatrix.t -> QQMatrix.t * QQMatrix.t
+val max_lds : QQMatrix.t -> QQMatrix.t -> QQMatrix.t * QQMatrix.t
 
 (** Given a matrix [A], find a pair of matrices [(M,T)] such that [MA = TM],
     [T] is lower-triangular, and the rowspace of [MA] is maximal. *)

--- a/srk/test/test_AlmostCommuting.ml
+++ b/srk/test/test_AlmostCommuting.ml
@@ -81,7 +81,7 @@ let phased_segment1 () =
                       [0; 0; 1]]
   in
   let input = [| (Commute, mA); (Reset, mB); (Commute, mC) |] in
-  let output = mk_phased_segment input in
+  let output = PhasedSegment.make input in
   let sim1 = mk_matrix [[0; 0; 1]] in
   let m1 = mk_matrix [[1]] in
   let phase1 = [| m1; m1; m1 |] in
@@ -114,7 +114,7 @@ let phased_segment2 () =
                       [0; 0; 1]]
   in
   let input = [| (Commute, mA); (Commute, mB); (Reset, mC) |] in
-  let output = mk_phased_segment input in
+  let output = PhasedSegment.make input in
   let sim1 = mk_matrix [[0; 0; 1]] in
   let m1 = mk_matrix [[1]] in
   let phase1 = [| m1; m1; m1 |] in

--- a/srk/test/test_AlmostCommuting.ml
+++ b/srk/test/test_AlmostCommuting.ml
@@ -55,11 +55,81 @@ let comm_segment3 () =
   let mS, _ = commuting_segment [| mA; mB |] in
   assert_equal_qqmatrix exp mS
 
+let phased_segment1 () = 
+  let mA = mk_matrix [[1; 0; 1];
+                      [0; 1; 1];
+                      [0; 0; 1]]
+  in
+  let mB = mk_matrix [[0; 0; 2];
+                      [0; 1; 0];
+                      [0; 0; 1]]
+  in
+  let mC = mk_matrix [[1; 0; 0];
+                      [0; 0; 3];
+                      [0; 0; 1]]
+  in
+  let input = [| (Commute, mA); (Reset, mB); (Commute, mC) |] in
+  let segment = mk_phased_segment input in
+  let sim1 = mk_matrix [[0; 0; 1]] in
+  let m1 = mk_matrix [[1]] in
+  let phase1 = [| m1; m1; m1 |] in
+  let sim2 = mk_matrix [[1; 0; 0];
+                        [0; 0; 1]]
+  in
+  let tA = mk_matrix [[1; 1]; [0; 1]] in
+  let tC = mk_matrix [[1; 0]; [0; 1]] in
+  let rB = mk_matrix [[2]; [1]] in
+  let phase2 = [| (Commute, tA); (Reset, rB); (Commute, tC) |] in
+  assert_equal_qqmatrix sim1 segment.sim1;
+  assert_equal_qqmatrix sim2 segment.sim2;
+  assert_equal_qqmatrix m1 (Array.get segment.phase1 0);
+  assert_equal_qqmatrix m1 (Array.get segment.phase1 1);
+  assert_equal_qqmatrix m1 (Array.get segment.phase1 2);
+  assert_equal_qqmatrix tA (let _, m = Array.get segment.phase2 0 in m);
+  assert_equal_qqmatrix rB (let _, m = Array.get segment.phase2 1 in m);
+  assert_equal_qqmatrix tC (let _, m = Array.get segment.phase2 2 in m)
+
+let phased_segment2 () = 
+  let mA = mk_matrix [[1; 0; 1];
+                      [0; 1; 1];
+                      [0; 0; 1]]
+  in
+  let mB = mk_matrix [[0; 0; 2];
+                      [0; 1; 0];
+                      [0; 0; 1]]
+  in
+  let mC = mk_matrix [[1; 0; 0];
+                      [0; 0; 3];
+                      [0; 0; 1]]
+  in
+  let input = [| (Commute, mA); (Commute, mB); (Reset, mC) |] in
+  let segment = mk_phased_segment input in
+  let sim1 = mk_matrix [[0; 0; 1]] in
+  let m1 = mk_matrix [[1]] in
+  let phase1 = [| m1; m1; m1 |] in
+  let sim2 = mk_matrix [[0; 1; 0];
+                        [0; 0; 1]]
+  in
+  let tA = mk_matrix [[1; 1]; [0; 1]] in
+  let tB = mk_matrix [[1; 0]; [0; 1]] in
+  let rC = mk_matrix [[3]; [1]] in
+  let phase2 = [| (Commute, tA); (Commute, tB); (Reset, rC) |] in
+  assert_equal_qqmatrix sim1 segment.sim1;
+  assert_equal_qqmatrix sim2 segment.sim2;
+  assert_equal_qqmatrix m1 (Array.get segment.phase1 0);
+  assert_equal_qqmatrix m1 (Array.get segment.phase1 1);
+  assert_equal_qqmatrix m1 (Array.get segment.phase1 2);
+  assert_equal_qqmatrix tA (let _, m = Array.get segment.phase2 0 in m);
+  assert_equal_qqmatrix tB (let _, m = Array.get segment.phase2 1 in m);
+  assert_equal_qqmatrix rC (let _, m = Array.get segment.phase2 2 in m)
+
 let suite = "AlmostCommuting" >::: [
   "comm_space1" >:: comm_space1;
   "comm_space2" >:: comm_space2;
   "comm_space3" >:: comm_space3;
   "comm_segment1" >:: comm_segment1;
   "comm_segment2" >:: comm_segment2;
-  "comm_segment3" >:: comm_segment3
+  "comm_segment3" >:: comm_segment3;
+  "phased_segment1" >:: phased_segment1;
+  "phased_segment2" >:: phased_segment2;
 ]

--- a/srk/test/test_AlmostCommuting.ml
+++ b/srk/test/test_AlmostCommuting.ml
@@ -31,7 +31,7 @@ let comm_space3 () =
 
 let comm_segment1 () =
   let eye = QQMatrix.identity [0; 1; 2] in
-  let mS, _ = commuting_segment [eye; eye] in
+  let mS, _ = commuting_segment [| eye; eye |] in
   assert_equal_qqmatrix eye mS
 
 let comm_segment2 () =
@@ -40,7 +40,7 @@ let comm_segment2 () =
                      [0; 1; 0];
                      [0; 0; 0]]
   in
-  let mS, _ = commuting_segment [eye; m] in
+  let mS, _ = commuting_segment [| eye; m |] in
   assert_equal_qqmatrix m mS
 
 let comm_segment3 () =
@@ -52,7 +52,7 @@ let comm_segment3 () =
                       [0; 2]]
   in
   let exp = mk_matrix [[0; 1]] in
-  let mS, _ = commuting_segment [mA; mB] in
+  let mS, _ = commuting_segment [| mA; mB |] in
   assert_equal_qqmatrix exp mS
 
 let suite = "AlmostCommuting" >::: [

--- a/srk/test/test_AlmostCommuting.ml
+++ b/srk/test/test_AlmostCommuting.ml
@@ -197,6 +197,40 @@ let phased_segment4 () =
   in
   assert_equal_phasedsegment expected output
 
+let phased_segment5 () = 
+  let mA = mk_matrix [[1; 0; 1];
+                      [0; 1; 1];
+                      [0; 0; 1]]
+  in
+  let mB = mk_matrix [[1; 0; -1];
+                      [0; 1; -1];
+                      [0; 0; 1]]
+  in
+  let mC = mk_matrix [[0; 0; 2];
+                      [0; 1; 2];
+                      [0; 0; 1]]
+  in
+  let mD = mk_matrix [[0; 1; 0];
+                      [0; 1; 0];
+                      [0; 0; 1]]
+  in
+  let input = [| (Reset, mA); (Ignore, mB); (Ignore, mC); (Ignore, mD) |] in
+  let output = PhasedSegment.make input in
+  let sim1 = mk_matrix [[0; 1; 0]; [0; 0; 1]] in
+  let sA = mk_matrix [[1; 1]; [0; 1]] in
+  let sB = mk_matrix [[1; -1]; [0; 1]] in
+  let sC = mk_matrix [[1; 2]; [0; 1]] in
+  let sD = mk_matrix [[1; 0]; [0; 1]] in
+  let phase1 = [| sA; sB; sC; sD |] in
+  let phase2 = [| (Reset, sA); (Ignore, mB); (Ignore, mC); (Ignore, mD) |] in
+  let expected =
+    { sim1 = sim1;
+      sim2 = sim1;
+      phase1 = phase1;
+      phase2 = phase2 }
+  in
+  assert_equal_phasedsegment expected output
+
 let almost_commuting1 () = 
   let mA = mk_matrix [[1; 0; 1];
                       [0; 1; 1];
@@ -229,5 +263,6 @@ let suite = "AlmostCommuting" >::: [
   "phased_segment2" >:: phased_segment2;
   "phased_segment3" >:: phased_segment3;
   "phased_segment4" >:: phased_segment4;
+  "phased_segment5" >:: phased_segment5;
   "almost_commuting1" >:: almost_commuting1;
 ]

--- a/srk/test/test_AlmostCommuting.ml
+++ b/srk/test/test_AlmostCommuting.ml
@@ -163,6 +163,40 @@ let phased_segment3 () =
   in
   assert_equal_phasedsegment expected output
 
+let phased_segment4 () = 
+  let mA = mk_matrix [[1; 0; 1];
+                      [0; 1; 1];
+                      [0; 0; 1]]
+  in
+  let mB = mk_matrix [[1; 0; -1];
+                      [0; 1; -1];
+                      [0; 0; 1]]
+  in
+  let mC = mk_matrix [[0; 0; 2];
+                      [0; 1; 2];
+                      [0; 0; 1]]
+  in
+  let mD = mk_matrix [[0; 1; 0];
+                      [0; 1; 0];
+                      [0; 0; 1]]
+  in
+  let input = [| (Commute, mA); (Commute, mB); (Commute, mC); (Commute, mD) |] in
+  let output = PhasedSegment.make input in
+  let sim1 = mk_matrix [[0; 1; 0]; [0; 0; 1]] in
+  let sA = mk_matrix [[1; 1]; [0; 1]] in
+  let sB = mk_matrix [[1; -1]; [0; 1]] in
+  let sC = mk_matrix [[1; 2]; [0; 1]] in
+  let sD = mk_matrix [[1; 0]; [0; 1]] in
+  let phase1 = [| sA; sB; sC; sD |] in
+  let phase2 = [| (Commute, sA); (Commute, sB); (Commute, sC); (Commute, sD) |] in
+  let expected =
+    { sim1 = sim1;
+      sim2 = sim1;
+      phase1 = phase1;
+      phase2 = phase2 }
+  in
+  assert_equal_phasedsegment expected output
+
 let suite = "AlmostCommuting" >::: [
   "comm_space1" >:: comm_space1;
   "comm_space2" >:: comm_space2;
@@ -173,4 +207,5 @@ let suite = "AlmostCommuting" >::: [
   "phased_segment1" >:: phased_segment1;
   "phased_segment2" >:: phased_segment2;
   "phased_segment3" >:: phased_segment3;
+  "phased_segment4" >:: phased_segment4;
 ]

--- a/srk/test/test_AlmostCommuting.ml
+++ b/srk/test/test_AlmostCommuting.ml
@@ -214,7 +214,7 @@ let almost_commuting1 () =
                       [0; 1; 0];
                       [0; 0; 1]]
   in
-  let output = PhasedSegmentation.best_almost_commuting [| mA; mB; mC; mD |] in
+  let output = PhasedSegmentation.make_naive [| mA; mB; mC; mD |] in
   let dim = QQVectorSpace.dimension (PhasedSegmentation.almost_commuting_space output) in
   assert_equal 3 dim
 

--- a/srk/test/test_AlmostCommuting.ml
+++ b/srk/test/test_AlmostCommuting.ml
@@ -197,6 +197,27 @@ let phased_segment4 () =
   in
   assert_equal_phasedsegment expected output
 
+let almost_commuting1 () = 
+  let mA = mk_matrix [[1; 0; 1];
+                      [0; 1; 1];
+                      [0; 0; 1]]
+  in
+  let mB = mk_matrix [[1; 0; -1];
+                      [0; 1; -1];
+                      [0; 0; 1]]
+  in
+  let mC = mk_matrix [[0; 0; 2];
+                      [0; 1; 2];
+                      [0; 0; 1]]
+  in
+  let mD = mk_matrix [[0; 1; 0];
+                      [0; 1; 0];
+                      [0; 0; 1]]
+  in
+  let output = PhasedSegmentation.best_almost_commuting [| mA; mB; mC; mD |] in
+  let dim = QQVectorSpace.dimension (PhasedSegmentation.almost_commuting_space output) in
+  assert_equal 3 dim
+
 let suite = "AlmostCommuting" >::: [
   "comm_space1" >:: comm_space1;
   "comm_space2" >:: comm_space2;
@@ -208,4 +229,5 @@ let suite = "AlmostCommuting" >::: [
   "phased_segment2" >:: phased_segment2;
   "phased_segment3" >:: phased_segment3;
   "phased_segment4" >:: phased_segment4;
+  "almost_commuting1" >:: almost_commuting1;
 ]

--- a/srk/test/test_AlmostCommuting.ml
+++ b/srk/test/test_AlmostCommuting.ml
@@ -17,7 +17,49 @@ let comm_space2 () =
   let res = commuting_space m eye in
   assert_equal_qqvectorspace (QQVectorSpace.of_matrix m) res
 
+let comm_space3 () =
+  let half = QQ.of_frac 1 2 in
+  let mA = mk_qqmatrix [[QQ.of_int 3; QQ.zero];
+                        [QQ.zero; half]]
+  in
+  let mB = mk_matrix [[0; 4];
+                      [0; 2]]
+  in
+  let exp = QQVectorSpace.of_matrix (mk_matrix [[0; 1]]) in
+  let res = commuting_space mA mB in
+  assert_equal_qqvectorspace exp res
+
+let comm1 () =
+  let eye = QQMatrix.identity [0; 1; 2] in
+  let mS, _ = commuting_segment [eye; eye] in
+  assert_equal_qqmatrix eye mS
+
+let comm2 () =
+  let eye = QQMatrix.identity [0; 1; 2] in
+  let m = mk_matrix [[1; 0; 0];
+                     [0; 1; 0];
+                     [0; 0; 0]]
+  in
+  let mS, _ = commuting_segment [eye; m] in
+  assert_equal_qqmatrix m mS
+
+let comm3 () =
+  let half = QQ.of_frac 1 2 in
+  let mA = mk_qqmatrix [[QQ.of_int 3; QQ.zero];
+                        [QQ.zero; half]]
+  in
+  let mB = mk_matrix [[0; 4];
+                      [0; 2]]
+  in
+  let exp = mk_matrix [[0; 1]] in
+  let mS, _ = commuting_segment [mA; mB] in
+  assert_equal_qqmatrix exp mS
+
 let suite = "AlmostCommuting" >::: [
   "comm_space1" >:: comm_space1;
-  "comm_space2" >:: comm_space2
+  "comm_space2" >:: comm_space2;
+  "comm_space3" >:: comm_space3;
+  "comm1" >:: comm1;
+  "comm2" >:: comm2;
+  "comm3" >:: comm3
 ]

--- a/srk/test/test_AlmostCommuting.ml
+++ b/srk/test/test_AlmostCommuting.ml
@@ -55,6 +55,18 @@ let comm_segment3 () =
   let mS, _ = commuting_segment [| mA; mB |] in
   assert_equal_qqmatrix exp mS
 
+(* let assert_equal_phased_segment p q =
+  assert_equal_qqmatrix p.sim1 q.sim1;
+  assert_equal_qqmatrix p.sim2 q.sim2;
+  Array.map2
+    (fun m1 m2 -> assert_equal_qqmatrix m1 m2)
+    p.phase1
+    q.phase1;
+  Array.map2
+    (fun (k1, m1) (k2, m2) -> assert_equal k1 k2; assert_equal_qqmatrix m1 m2)
+    p.phase2
+    q.phase2 *)
+
 let phased_segment1 () = 
   let mA = mk_matrix [[1; 0; 1];
                       [0; 1; 1];
@@ -69,7 +81,7 @@ let phased_segment1 () =
                       [0; 0; 1]]
   in
   let input = [| (Commute, mA); (Reset, mB); (Commute, mC) |] in
-  let segment = mk_phased_segment input in
+  let output = mk_phased_segment input in
   let sim1 = mk_matrix [[0; 0; 1]] in
   let m1 = mk_matrix [[1]] in
   let phase1 = [| m1; m1; m1 |] in
@@ -80,14 +92,13 @@ let phased_segment1 () =
   let tC = mk_matrix [[1; 0]; [0; 1]] in
   let rB = mk_matrix [[2]; [1]] in
   let phase2 = [| (Commute, tA); (Reset, rB); (Commute, tC) |] in
-  assert_equal_qqmatrix sim1 segment.sim1;
-  assert_equal_qqmatrix sim2 segment.sim2;
-  assert_equal_qqmatrix m1 (Array.get segment.phase1 0);
-  assert_equal_qqmatrix m1 (Array.get segment.phase1 1);
-  assert_equal_qqmatrix m1 (Array.get segment.phase1 2);
-  assert_equal_qqmatrix tA (let _, m = Array.get segment.phase2 0 in m);
-  assert_equal_qqmatrix rB (let _, m = Array.get segment.phase2 1 in m);
-  assert_equal_qqmatrix tC (let _, m = Array.get segment.phase2 2 in m)
+  let expected =
+    { sim1 = sim1;
+      sim2 = sim2;
+      phase1 = phase1;
+      phase2 = phase2 }
+  in
+  assert_equal_phasedsegment expected output
 
 let phased_segment2 () = 
   let mA = mk_matrix [[1; 0; 1];
@@ -103,7 +114,7 @@ let phased_segment2 () =
                       [0; 0; 1]]
   in
   let input = [| (Commute, mA); (Commute, mB); (Reset, mC) |] in
-  let segment = mk_phased_segment input in
+  let output = mk_phased_segment input in
   let sim1 = mk_matrix [[0; 0; 1]] in
   let m1 = mk_matrix [[1]] in
   let phase1 = [| m1; m1; m1 |] in
@@ -114,14 +125,13 @@ let phased_segment2 () =
   let tB = mk_matrix [[1; 0]; [0; 1]] in
   let rC = mk_matrix [[3]; [1]] in
   let phase2 = [| (Commute, tA); (Commute, tB); (Reset, rC) |] in
-  assert_equal_qqmatrix sim1 segment.sim1;
-  assert_equal_qqmatrix sim2 segment.sim2;
-  assert_equal_qqmatrix m1 (Array.get segment.phase1 0);
-  assert_equal_qqmatrix m1 (Array.get segment.phase1 1);
-  assert_equal_qqmatrix m1 (Array.get segment.phase1 2);
-  assert_equal_qqmatrix tA (let _, m = Array.get segment.phase2 0 in m);
-  assert_equal_qqmatrix tB (let _, m = Array.get segment.phase2 1 in m);
-  assert_equal_qqmatrix rC (let _, m = Array.get segment.phase2 2 in m)
+  let expected =
+    { sim1 = sim1;
+      sim2 = sim2;
+      phase1 = phase1;
+      phase2 = phase2 }
+  in
+  assert_equal_phasedsegment expected output
 
 let suite = "AlmostCommuting" >::: [
   "comm_space1" >:: comm_space1;

--- a/srk/test/test_AlmostCommuting.ml
+++ b/srk/test/test_AlmostCommuting.ml
@@ -1,0 +1,23 @@
+open OUnit
+open AlmostCommuting
+open Linear
+open Test_pervasives
+
+let comm_space1 () =
+  let eye = QQMatrix.identity [0; 1; 2] in
+  let res = commuting_space eye eye in
+  assert_equal_qqvectorspace (QQVectorSpace.of_matrix eye) res
+
+let comm_space2 () =
+  let eye = QQMatrix.identity [0; 1; 2] in
+  let m = mk_matrix [[1; 0; 0];
+                     [0; 1; 0];
+                     [0; 0; 0]]
+  in
+  let res = commuting_space m eye in
+  assert_equal_qqvectorspace (QQVectorSpace.of_matrix m) res
+
+let suite = "AlmostCommuting" >::: [
+  "comm_space1" >:: comm_space1;
+  "comm_space2" >:: comm_space2
+]

--- a/srk/test/test_AlmostCommuting.ml
+++ b/srk/test/test_AlmostCommuting.ml
@@ -29,12 +29,12 @@ let comm_space3 () =
   let res = commuting_space mA mB in
   assert_equal_qqvectorspace exp res
 
-let comm1 () =
+let comm_segment1 () =
   let eye = QQMatrix.identity [0; 1; 2] in
   let mS, _ = commuting_segment [eye; eye] in
   assert_equal_qqmatrix eye mS
 
-let comm2 () =
+let comm_segment2 () =
   let eye = QQMatrix.identity [0; 1; 2] in
   let m = mk_matrix [[1; 0; 0];
                      [0; 1; 0];
@@ -43,7 +43,7 @@ let comm2 () =
   let mS, _ = commuting_segment [eye; m] in
   assert_equal_qqmatrix m mS
 
-let comm3 () =
+let comm_segment3 () =
   let half = QQ.of_frac 1 2 in
   let mA = mk_qqmatrix [[QQ.of_int 3; QQ.zero];
                         [QQ.zero; half]]
@@ -59,7 +59,7 @@ let suite = "AlmostCommuting" >::: [
   "comm_space1" >:: comm_space1;
   "comm_space2" >:: comm_space2;
   "comm_space3" >:: comm_space3;
-  "comm1" >:: comm1;
-  "comm2" >:: comm2;
-  "comm3" >:: comm3
+  "comm_segment1" >:: comm_segment1;
+  "comm_segment2" >:: comm_segment2;
+  "comm_segment3" >:: comm_segment3
 ]

--- a/srk/test/test_pervasives.ml
+++ b/srk/test/test_pervasives.ml
@@ -86,6 +86,9 @@ let assert_equal_qqmatrix x y =
 let assert_equal_qqvector x y =
   assert_equal ~cmp:Linear.QQVector.equal ~printer:Linear.QQVector.show x y
 
+let assert_equal_qqvectorspace x y =
+  assert_equal ~cmp:Linear.QQVectorSpace.equal ~printer:Linear.QQVectorSpace.show x y
+
 let assert_equal_exppoly x y =
   assert_equal ~cmp:ExpPolynomial.equal ~printer:ExpPolynomial.show x y
 

--- a/srk/test/test_pervasives.ml
+++ b/srk/test/test_pervasives.ml
@@ -89,6 +89,9 @@ let assert_equal_qqvector x y =
 let assert_equal_qqvectorspace x y =
   assert_equal ~cmp:Linear.QQVectorSpace.equal ~printer:Linear.QQVectorSpace.show x y
 
+let assert_equal_phasedsegment x y =
+  assert_equal ~cmp:AlmostCommuting.PhasedSegment.equal ~printer:AlmostCommuting.PhasedSegment.show x y
+
 let assert_equal_exppoly x y =
   assert_equal ~cmp:ExpPolynomial.equal ~printer:ExpPolynomial.show x y
 

--- a/srk/test/test_srk.ml
+++ b/srk/test/test_srk.ml
@@ -17,6 +17,7 @@ let suite = "Main" >::: [
     Test_abstract.suite;
     Test_iteration.suite;
     Test_LinearSemiautomaton.suite;
+    Test_AlmostCommuting.suite;
     Test_transition.suite;
     Test_WeightedGraph.suite;
 ]


### PR DESCRIPTION
As a first step I implemented the naive abstraction algorithm which explores all partitions of the LTS (see PhasedSegmentation.make_naive).

Since I'm not familiar with best practices in OCaml, I don't know if it makes sense to wrap the functions in `almostCommuting.mli` in modules, or if this is an overkill.