### PR TITLE
Variant of subexponential abstraction algorithm

### DIFF
--- a/srk/src/almostCommuting.ml
+++ b/srk/src/almostCommuting.ml
@@ -72,8 +72,6 @@ module PhasedSegment = struct
       p.phase2
       q.phase2
 
-  let dimension p = VS.dimension (VS.of_matrix p.sim2)
-
   let make pairs =
     if Array.length pairs == 0 then
       raise (Invalid_argument "Array of matrices should not be empty")

--- a/srk/src/almostCommuting.ml
+++ b/srk/src/almostCommuting.ml
@@ -143,16 +143,17 @@ module PhasedSegmentation = struct
     let pairs = Array.map (fun mM -> (Ignore, mM)) matrices in
     let rec iter ps dim i =
       if i >= (Array.length ps) then
-        BatQueue.push (PhasedSegment.make ps) segments;
-      let ps' = set_kind ps i Reset in
-      let dim' = PhasedSegment.dimension (PhasedSegment.make ps') in
-      if dim' == dim then
-        iter ps' dim' (i+1)
+        BatQueue.push (PhasedSegment.make ps) segments
       else
-        let ps'' = set_kind ps i Commute in
-        let dim'' = PhasedSegment.dimension (PhasedSegment.make ps'') in
-        iter ps' dim' (i+1);
-        iter ps'' dim'' (i+1)
+        let ps' = set_kind ps i Reset in
+        let dim' = PhasedSegment.dimension (PhasedSegment.make ps') in
+        if dim' == dim then
+          iter ps' dim' (i+1)
+        else
+          let ps'' = set_kind ps i Commute in
+          let dim'' = PhasedSegment.dimension (PhasedSegment.make ps'') in
+          iter ps' dim' (i+1);
+          iter ps'' dim'' (i+1)
     in
     iter pairs (PhasedSegment.dimension (PhasedSegment.make pairs)) 0;
     BatList.of_enum (BatQueue.enum segments)

--- a/srk/src/almostCommuting.ml
+++ b/srk/src/almostCommuting.ml
@@ -156,7 +156,7 @@ module PhasedSegmentation = struct
           let seg' = PhasedSegment.make ps' in
           let ps'' = set_kind ps i Commute in
           let seg'' = PhasedSegment.make ps'' in
-          (* We only have to consider the reset extension if it subsumes the non-reset extension *)
+          (* It suffices to proceed with only the reset extension if it subsumes the non-reset extension *)
           if (VS.subspace (VS.of_matrix seg''.sim2) (VS.of_matrix seg'.sim2)) then
             iter ps' seg' (i+1)
           else

--- a/srk/src/almostCommuting.ml
+++ b/srk/src/almostCommuting.ml
@@ -117,12 +117,6 @@ module PhasedSegment = struct
 
 end
 
-let set_kind ps i k =
-  let ps' = Array.copy ps in
-  let _, mM = Array.get ps' i in
-  Array.set ps' i (k, mM);
-  ps'
-
 module PhasedSegmentation = struct
 
   type t = phased_segment list
@@ -142,6 +136,12 @@ module PhasedSegmentation = struct
     let push s =
       current_space := VS.sum !current_space (VS.of_matrix s.sim2);
       BatQueue.push s segments
+    in
+    let set_kind ps i k =
+      let ps' = Array.copy ps in
+      let _, mM = Array.get ps' i in
+      Array.set ps' i (k, mM);
+      ps'
     in
     (* Start with a segment where all matrices are non-resets *)
     let pairs = Array.map (fun mM -> (Commute, mM)) matrices in

--- a/srk/src/almostCommuting.ml
+++ b/srk/src/almostCommuting.ml
@@ -154,11 +154,12 @@ module PhasedSegmentation = struct
         else
           let ps' = set_kind ps i Reset in
           let seg' = PhasedSegment.make ps' in
-          if (PhasedSegment.dimension seg') == (PhasedSegment.dimension seg) then
+          let ps'' = set_kind ps i Commute in
+          let seg'' = PhasedSegment.make ps'' in
+          (* We only have to consider the reset extension if it subsumes the non-reset extension *)
+          if (VS.subspace (VS.of_matrix seg''.sim2) (VS.of_matrix seg'.sim2)) then
             iter ps' seg' (i+1)
           else
-            let ps'' = set_kind ps i Commute in
-            let seg'' = PhasedSegment.make ps'' in
             iter ps' seg' (i+1);
             iter ps'' seg'' (i+1)
     in

--- a/srk/src/almostCommuting.ml
+++ b/srk/src/almostCommuting.ml
@@ -167,7 +167,6 @@ module PhasedSegmentation = struct
     let seg = PhasedSegment.make pairs in
     iter pairs seg 0;
     BatList.of_enum (BatQueue.enum segments)
-      
 
   let almost_commuting_space segmentation =
     List.fold_left

--- a/srk/src/almostCommuting.mli
+++ b/srk/src/almostCommuting.mli
@@ -32,7 +32,7 @@ module PhasedSegmentation : sig
    (** Computes a phased segmentation for the given matrices by exhaustively exploring all partitions *)
    val make_naive : QQMatrix.t array -> t
 
-   (** Computes a phased segmentation for the given matrices. Running time is O(2^d) where d is the dimension of the LTS *)
+   (** Computes a phased segmentation for the given matrices *)
    val make : QQMatrix.t array -> t
 
    (** Returns the vector space where the given segmentation almost commutes *)

--- a/srk/src/almostCommuting.mli
+++ b/srk/src/almostCommuting.mli
@@ -32,6 +32,9 @@ module PhasedSegmentation : sig
    (** Computes a phased segmentation for the given matrices by exhaustively exploring all partitions *)
    val make_naive : QQMatrix.t array -> t
 
+   (** Computes a phased segmentation for the given matrices. Running time is O(2^d) where d is the dimension of the LTS *)
+   val make : QQMatrix.t array -> t
+
    (** Returns the vector space where the given segmentation almost commutes *)
    val almost_commuting_space : t -> QQVectorSpace.t
 

--- a/srk/test/test_AlmostCommuting.ml
+++ b/srk/test/test_AlmostCommuting.ml
@@ -218,6 +218,27 @@ let almost_commuting1 () =
   let dim = QQVectorSpace.dimension (PhasedSegmentation.almost_commuting_space output) in
   assert_equal 3 dim
 
+let almost_commuting2 () = 
+  let mA = mk_matrix [[1; 0; 1];
+                      [0; 1; 1];
+                      [0; 0; 1]]
+  in
+  let mB = mk_matrix [[1; 0; -1];
+                      [0; 1; -1];
+                      [0; 0; 1]]
+  in
+  let mC = mk_matrix [[0; 0; 2];
+                      [0; 1; 2];
+                      [0; 0; 1]]
+  in
+  let mD = mk_matrix [[0; 1; 0];
+                      [0; 1; 0];
+                      [0; 0; 1]]
+  in
+  let output = PhasedSegmentation.make [| mA; mB; mC; mD |] in
+  let dim = QQVectorSpace.dimension (PhasedSegmentation.almost_commuting_space output) in
+  assert_equal 3 dim
+
 let suite = "AlmostCommuting" >::: [
   "comm_space1" >:: comm_space1;
   "comm_space2" >:: comm_space2;
@@ -230,4 +251,5 @@ let suite = "AlmostCommuting" >::: [
   "phased_segment3" >:: phased_segment3;
   "phased_segment4" >:: phased_segment4;
   "almost_commuting1" >:: almost_commuting1;
+  "almost_commuting2" >:: almost_commuting2;
 ]


### PR DESCRIPTION
This here is a version of the algorithm we discussed last week. It does the subsumption check only for the reset branch. The subsumption check for the non-resets might introduce too much overhead in practice.