### PR TITLE
added type info to substitute. fixed bug in substitute_sym

### DIFF
--- a/duet/cra.ml
+++ b/duet/cra.ml
@@ -884,7 +884,7 @@ let lift_universals srk phi =
        let shift_conjuncts =
          conjuncts |> List.map (fun (nb,phi) ->
                      let shift = max_nb - nb in
-                     substitute srk (fun i -> mk_var srk (i + shift) `TyInt) phi)
+                     substitute srk (fun (i, typ) -> mk_var srk (i + shift) typ) phi)
        in
        (max_nb, mk_and srk shift_conjuncts)
     | `Or disjuncts ->
@@ -901,7 +901,7 @@ let lift_universals srk phi =
            disjuncts |> BatList.mapi (fun idx (nb,phi) ->
                             let shift = max_nb - nb in
                             mk_and srk
-                              [substitute srk (fun i -> mk_var srk (i + shift) `TyInt) phi;
+                              [substitute srk (fun (i, typ) -> mk_var srk (i + shift) typ) phi;
                                mk_eq srk sk (mk_int srk idx)])
          in
          (max_nb, mk_or srk shift_disjuncts)

--- a/srk/src/chc.ml
+++ b/srk/src/chc.ml
@@ -339,7 +339,7 @@ module ChcSrkZ3 = struct
               srk 
               ((substitute 
                   srk 
-                  (fun ind -> 
+                  (fun (ind,_) -> 
                      if BatHashtbl.mem ind_to_sym ind 
                      then mk_const srk (BatHashtbl.find ind_to_sym ind)
                      else failwith "Free var in rule formula not bound in rel")

--- a/srk/src/interpretation.ml
+++ b/srk/src/interpretation.ml
@@ -98,7 +98,7 @@ let unfold_app interpretation func actuals =
     let env =
       List.fold_right Env.push actuals Env.empty
     in
-    substitute srk (Env.find env) body
+    substitute srk (fun (i, _) -> (Env.find env) i) body
   | _ ->
     invalid_arg "unfold_app: not a function symbol"
 

--- a/srk/src/srkZ3.ml
+++ b/srk/src/srkZ3.ml
@@ -647,7 +647,7 @@ module CHC = struct
       let table = Hashtbl.create 991 in
       BatHashtbl.enum var_table
       |> BatEnum.iteri (fun i (j, typ) -> Hashtbl.add table j (mk_var srk i typ));
-      fun i -> Hashtbl.find table i
+      fun (i, _) -> Hashtbl.find table i
     in
     let rule =
       match destruct srk conclusion with

--- a/srk/src/syntax.mli
+++ b/srk/src/syntax.mli
@@ -134,7 +134,7 @@ val mk_iff : 'a context -> 'a formula -> 'a formula -> 'a formula
    symbol with De Bruijn [i] with the expression [subst i].  If [subst
    i] contains free variables, capture is avoided. *)
 val substitute : 'a context ->
-  (int -> ('a,'b) expr) -> ('a,'typ) expr -> ('a,'typ) expr
+  (int * typ_fo -> ('a,'b) expr) -> ('a,'typ) expr -> ('a,'typ) expr
 
 (** [substitute_const srk subst exp] replaces each occurrence of a
    constant symbol [s] with the expression [subst s].  If [subst s]

--- a/srk/test/test_pervasives.ml
+++ b/srk/test/test_pervasives.ml
@@ -41,6 +41,10 @@ let x' : 'a term = Ctx.mk_const xsym'
 let y' : 'a term = Ctx.mk_const ysym'
 let z' : 'a term = Ctx.mk_const zsym'
 
+let fsym = Ctx.mk_symbol ~name:"f" (`TyFun ([`TyInt], `TyInt))
+let f : Ctx.term -> Ctx.term =
+  fun x -> Ctx.mk_app fsym [(x :> (Ctx.t, typ_fo) expr)]
+
 let frac num den = Ctx.mk_real (QQ.of_frac num den)
 let int k = Ctx.mk_real (QQ.of_int k)
 

--- a/srk/test/test_smt.ml
+++ b/srk/test/test_smt.ml
@@ -190,7 +190,7 @@ let substitute_solution fp expr =
     | `App (_, []) -> expr
     | `App (relation, args) ->
       (substitute srk
-         (List.nth args)
+         (fun (i, _) -> List.nth args i)
          (SrkZ3.CHC.get_solution fp relation) :> ('a,typ_fo) expr)
     | _ -> expr
   in

--- a/srk/test/test_syntax.ml
+++ b/srk/test/test_syntax.ml
@@ -8,8 +8,8 @@ let substitute () =
   let subst =
     let open Infix in
     function
-    | 0 -> x
-    | 2 -> (var 0 `TyInt)
+    | 0, _ -> x
+    | 2, _ -> (var 0 `TyInt)
     | _ -> raise Not_found
   in
   let phi =
@@ -27,6 +27,36 @@ let substitute () =
            && x < (var 1 `TyInt)))
   in
   assert_equal_formula (substitute srk subst phi) psi
+
+let subst_sym1 () =
+  let phi =
+    let open Infix in
+    exists `TyInt (forall `TyInt (f (var 1 `TyInt) = (int 99)))
+  in
+  let psi = 
+    substitute_sym
+      srk
+      (fun sym -> mk_app srk sym [(mk_var srk 0 `TyInt)]) 
+      phi
+  in
+  assert_equal_formula phi psi
+
+let subst_sym2 () =
+  let phi =
+    let open Infix in
+    exists `TyInt (forall `TyInt (f (var 1 `TyInt) = (int 99)))
+  in
+  let phi' = 
+    substitute_sym
+      srk
+      (fun sym -> mk_app srk sym [(mk_var srk 1 `TyInt)]) 
+      phi
+  in
+  let psi =
+    let open Infix in
+    exists `TyInt (forall `TyInt (f (var 2 `TyInt) = (int 99)))
+  in
+  assert_equal_formula phi' psi
 
 let existential_closure1 () =
   let phi =
@@ -119,6 +149,8 @@ let elim_ite3 () =
 let suite = "Syntax" >:::
   [
     "substitute" >:: substitute;
+    "subst_sym1" >:: subst_sym1;
+    "subst_sym2" >:: subst_sym2;
     "existential_closure1" >:: existential_closure1;
     "existential_closure2" >:: existential_closure2;
     "prenex" >:: prenex;


### PR DESCRIPTION
Previous discussion:

https://github.com/zkincaid/duet/pull/20#discussion_r550509824
https://github.com/zkincaid/duet/pull/20#discussion_r550578419

A function may have more free vars than it does parameters in the case that the user wants an uncaptured var to appear in the resulting term. For example, consider if the user wants to replace the term "f(x)" with the term "f(x + var 0)". I added tests to cover previous bug and to show desire for having free vars beyond # of parameters. Note this is also in line with current specification in .mli file.