### PR TITLE
arrays as first order types

### DIFF
--- a/duet/cra.ml
+++ b/duet/cra.ml
@@ -140,12 +140,12 @@ module K = struct
 end
 
 type ptr_term =
-  { ptr_val : Ctx.term;
-    ptr_pos : Ctx.term;
-    ptr_width : Ctx.term }
+  { ptr_val : Ctx.arith_term;
+    ptr_pos : Ctx.arith_term;
+    ptr_width : Ctx.arith_term }
 
 type term =
-  | TInt of Ctx.term
+  | TInt of Ctx.arith_term
   | TPointer of ptr_term
 
 let int_binop op left right =
@@ -876,9 +876,10 @@ let lift_universals srk phi =
   let alg = function
     | `Tru -> (0, mk_true srk)
     | `Fls -> (0, mk_false srk)
-    | `Atom (`Eq, x, y) -> (0, mk_eq srk x y)
-    | `Atom (`Lt, x, y) -> (0, mk_lt srk x y)
-    | `Atom (`Leq, x, y) -> (0, mk_leq srk x y)
+    | `Atom (`Arith (`Eq, x, y)) -> (0, mk_eq srk x y)
+    | `Atom (`Arith (`Lt, x, y)) -> (0, mk_lt srk x y)
+    | `Atom (`Arith (`Leq, x, y)) -> (0, mk_leq srk x y)
+    | `Atom (`ArrEq (a, b)) -> (0, mk_arr_eq srk a b)
     | `And conjuncts ->
        let max_nb = List.fold_left max 0 (List.map fst conjuncts) in
        let shift_conjuncts =
@@ -1012,18 +1013,18 @@ let resource_bound_analysis file =
             | `Sat (lower, upper) ->
               begin match lower with
                 | Some lower ->
-                  logf ~level:`always "%a <= cost" (Syntax.Term.pp srk) lower;
+                  logf ~level:`always "%a <= cost" (Syntax.ArithTerm.pp srk) lower;
                   logf ~level:`always "%a is o(%a)"
                     Varinfo.pp procedure
-                    BigO.pp (BigO.of_term srk lower)
+                    BigO.pp (BigO.of_arith_term srk lower)
                 | None -> ()
               end;
               begin match upper with
                 | Some upper ->
-                  logf ~level:`always "cost <= %a" (Syntax.Term.pp srk) upper;
+                  logf ~level:`always "cost <= %a" (Syntax.ArithTerm.pp srk) upper;
                   logf ~level:`always "%a is O(%a)"
                   Varinfo.pp procedure
-                  BigO.pp (BigO.of_term srk upper)
+                  BigO.pp (BigO.of_arith_term srk upper)
                 | None -> ()
               end
             | `Unsat ->

--- a/srk/src/abstract.mli
+++ b/srk/src/abstract.mli
@@ -5,19 +5,19 @@ open Syntax
     projected onto the given set of symbols.  The basis is represented as a
     list of terms, with the interpretation that a point [p] belongs to the
     affine hull if every term in the list evaluates to 0 at [p]. *)
-val affine_hull : 'a context -> 'a formula -> symbol list -> 'a term list
+val affine_hull : 'a context -> 'a formula -> symbol list -> 'a arith_term list
 
 (** Let [cs = t1, ..., tn] be a list of terms. [t1, ..., tn] generates
    a linear space of functions from interpretations to rationals;
    [vanishing_space srk phi cs] computes a basis for the subspace of
    functions from interpretations to rationals that evaluate to zero
    on all models of [phi]. *)
-val vanishing_space : 'a context -> 'a formula -> 'a term array -> Linear.QQVectorSpace.t
+val vanishing_space : 'a context -> 'a formula -> 'a arith_term array -> Linear.QQVectorSpace.t
 
 (** [boxify srk phi terms] computes the strongest formula of the form
     [/\ { lo <= t <= hi : t in terms }]
     that is implied by [phi]. *)
-val boxify : 'a context -> 'a formula -> 'a term list -> 'a formula
+val boxify : 'a context -> 'a formula -> 'a arith_term list -> 'a formula
 
 (** [abstract ?exists srk man phi] computes the strongest property that is
     implied by [phi] which is expressible within a given abstract domain.  The
@@ -31,7 +31,7 @@ val abstract : ?exists:(symbol -> bool) ->
 
 module Sign : sig
   type 'a t
-  val abstract : 'a context -> 'a formula -> 'a term list -> 'a t
+  val abstract : 'a context -> 'a formula -> 'a arith_term list -> 'a t
   val formula_of : 'a context -> 'a t -> 'a formula
   val join : 'a t -> 'a t -> 'a t
   val equal : 'a t -> 'a t -> bool

--- a/srk/src/bigO.ml
+++ b/srk/src/bigO.ml
@@ -69,7 +69,7 @@ let maximum x y =
   | `Geq -> x
   | `Unknown -> Unknown
 
-let of_term srk term =
+let of_arith_term srk term =
   Nonlinear.ensure_symbols srk;
   Wedge.ensure_min_max srk;
 
@@ -79,12 +79,12 @@ let of_term srk term =
   let max = get_named_symbol srk "max" in
 
   let rec go term =
-    match Term.destruct srk term with
+    match ArithTerm.destruct srk term with
     | `Real _ -> Polynomial 0
     | `App (_, []) -> Polynomial 1
     | `App (func, [base; exp]) when func = pow ->
       let exp = match Expr.refine srk exp with
-        | `Term t -> t
+        | `ArithTerm t -> t
         | _ -> assert false
       in
       begin match destruct srk base, go exp with
@@ -93,7 +93,7 @@ let of_term srk term =
       end
     | `App (func, [_; exp]) when func = log ->
       let exp = match Expr.refine srk exp with
-        | `Term t -> t
+        | `ArithTerm t -> t
         | _ -> assert false
       in
       begin match go exp with
@@ -105,13 +105,13 @@ let of_term srk term =
       end
     | `App (func, [x; y]) when func = min ->
       let (x, y) = match Expr.refine srk x, Expr.refine srk y with
-        | (`Term s, `Term t) -> (s, t)
+        | (`ArithTerm s, `ArithTerm t) -> (s, t)
         | (_, _) -> assert false
       in
       minimum (go x) (go y)
     | `App (func, [x; y]) when func = max ->
       let (x, y) = match Expr.refine srk x, Expr.refine srk y with
-        | (`Term s, `Term t) -> (s, t)
+        | (`ArithTerm s, `ArithTerm t) -> (s, t)
         | (_, _) -> assert false
       in
       maximum (go x) (go y)

--- a/srk/src/bigO.mli
+++ b/srk/src/bigO.mli
@@ -3,4 +3,4 @@
 open Syntax
 type t
 val pp : Format.formatter -> t -> unit
-val of_term : 'a context -> 'a term -> t
+val of_arith_term : 'a context -> 'a arith_term -> t

--- a/srk/src/coordinateSystem.mli
+++ b/srk/src/coordinateSystem.mli
@@ -27,7 +27,7 @@ val get_context : 'a t -> 'a context
 val copy : 'a t -> 'a t
 
 (** Extend a coordinate system to admit a term *)
-val admit_term : 'a t -> 'a term -> unit
+val admit_term : 'a t -> 'a arith_term -> unit
 
 (** Extend a coordinate system with one additional coordinate term, if that
     coordinate does not already belong to the system. *)
@@ -48,9 +48,9 @@ val real_dim : 'a t -> int
 val destruct_coordinate : 'a t -> int -> cs_term
 
 (** Find the term associated with a coordinate *)
-val term_of_coordinate : 'a t -> int -> 'a term
+val term_of_coordinate : 'a t -> int -> 'a arith_term
 
-val term_of_vec : 'a t -> Linear.QQVector.t -> 'a term
+val term_of_vec : 'a t -> Linear.QQVector.t -> 'a arith_term
 
 (** Find the coordinate associated with an coordinate term.  If the coordinate
     term is does not belong to the coorindate system and [admit] is set then
@@ -60,7 +60,7 @@ val cs_term_id : ?admit:bool -> 'a t -> cs_term -> int
 (** Find the vector associated with an admissible term.  If the term is
     inadmissible and [admit] is set then extend the coordinate system; otherwise,
     raise [Not_found]. *)
-val vec_of_term : ?admit:bool -> 'a t -> 'a term -> Linear.QQVector.t
+val vec_of_term : ?admit:bool -> 'a t -> 'a arith_term -> Linear.QQVector.t
 
 val type_of_id : 'a t -> int -> [ `TyInt | `TyReal ]
 
@@ -72,7 +72,7 @@ val type_of_polynomial : 'a t -> Polynomial.QQXs.t -> [ `TyInt | `TyReal ]
 
 (** Find a polynomial associated with an admissible term over
     {i non-multiplicative} coordinates. *)
-val polynomial_of_term : 'a t -> 'a term -> Polynomial.QQXs.t
+val polynomial_of_term : 'a t -> 'a arith_term -> Polynomial.QQXs.t
 
 (** Convert a vector to a polynomial {i without multiplicative coordinates}.
     Multiplicative coordinates are expanded into higher-degree polynomials
@@ -81,10 +81,10 @@ val polynomial_of_vec : 'a t -> Linear.QQVector.t -> Polynomial.QQXs.t
 
 val polynomial_of_coordinate : 'a t -> int -> Polynomial.QQXs.t
 
-val term_of_polynomial : 'a t -> Polynomial.QQXs.t -> 'a term
+val term_of_polynomial : 'a t -> Polynomial.QQXs.t -> 'a arith_term
 
 (** Does a coordinate system admit the given term? *)
-val admits : 'a t -> 'a term -> bool
+val admits : 'a t -> 'a arith_term -> bool
 
 (** [project_ideal cs basis subterm p] takes as input a coordinate
    system [cs], a basis for a polynomial ideal [basis], and two
@@ -99,7 +99,7 @@ val project_ideal : 'a t ->
   Polynomial.QQXs.t list ->
   ?subterm:(symbol -> bool) ->
   (symbol -> bool) ->
-  (int * 'a term * 'a formula) list
+  (int * 'a arith_term * 'a formula) list
 
 (** Find the set of all coordinates that are associated with subterms of the
     term associated with a given coordinate. *)

--- a/srk/src/expPolynomial.mli
+++ b/srk/src/expPolynomial.mli
@@ -40,7 +40,7 @@ val summation : t -> t
 val solve_rec : ?initial:QQ.t -> QQ.t -> t -> t
 
 (** [term_of srk t f] computes a term representing [f(t)]. *)
-val term_of : ('a context) -> 'a term -> t -> 'a term
+val term_of : ('a context) -> 'a arith_term -> t -> 'a arith_term
 
 val eval : t -> int -> QQ.t
 
@@ -111,7 +111,7 @@ module UltPeriodic : sig
 
   (** [term_of srk q r f] computes a term representing [f(qp + r)],
       where [p] is the period of [f]. *)
-  val term_of : 'a context -> 'a term -> 'a term -> t -> 'a term
+  val term_of : 'a context -> 'a arith_term -> 'a arith_term -> t -> 'a arith_term
 
   val scalar : QQ.t -> t
   val of_polynomial : Polynomial.QQX.t -> t

--- a/srk/src/interpretation.ml
+++ b/srk/src/interpretation.ml
@@ -133,7 +133,7 @@ let rec evaluate_term interp ?(env=Env.empty) term =
       begin match Expr.refine interp.srk (unfold_app interp func args) with
         | `ArithTerm t ->
           evaluate_term interp ~env t
-        | `ArrTerm _ -> assert false
+        | `ArrTerm _
         | `Formula _ ->
           invalid_arg "evaluate_term: ill-typed function application"
       end
@@ -395,9 +395,8 @@ let select_implicant interp ?(env=Env.empty) phi =
 
 let destruct_atom srk phi =
   match Formula.destruct srk phi with
-  | `Atom (`Arith (op, s, t)) -> `Comparison (op, s, t)
-  | `Atom (`ArrEq _) ->  invalid_arg @@ Format.asprintf 
-      "destruct_atom: %a is syntactic sugar for quantified expression" (Formula.pp srk) phi
+  | `Atom (`Arith (op, s, t)) -> `Arith_Comparison (op, s, t)
+  | `Atom (`ArrEq (a, b)) ->  `Arr_Comparison (a, b)
   | `Proposition (`App (k, [])) ->
     `Literal (`Pos, `Const k)
   | `Proposition (`Var i) -> `Literal (`Pos, `Var i)
@@ -409,8 +408,8 @@ let destruct_atom srk phi =
     end
   | `Tru ->
     let zero = mk_real srk QQ.zero in
-    `Comparison (`Eq, zero, zero)
-  | `Fls -> `Comparison (`Eq, mk_real srk QQ.zero, mk_real srk QQ.one)
+    `Arith_Comparison (`Eq, zero, zero)
+  | `Fls -> `Arith_Comparison (`Eq, mk_real srk QQ.zero, mk_real srk QQ.one)
   | _ ->
     invalid_arg @@ Format.asprintf "destruct_atom: %a is not atomic" (Formula.pp srk) phi
 

--- a/srk/src/interpretation.ml
+++ b/srk/src/interpretation.ml
@@ -395,8 +395,8 @@ let select_implicant interp ?(env=Env.empty) phi =
 
 let destruct_atom srk phi =
   match Formula.destruct srk phi with
-  | `Atom (`Arith (op, s, t)) -> `Arith_Comparison (op, s, t)
-  | `Atom (`ArrEq (a, b)) ->  `Arr_Comparison (a, b)
+  | `Atom (`Arith (op, s, t)) -> `ArithComparison (op, s, t)
+  | `Atom (`ArrEq (a, b)) ->  `ArrEq (a, b)
   | `Proposition (`App (k, [])) ->
     `Literal (`Pos, `Const k)
   | `Proposition (`Var i) -> `Literal (`Pos, `Var i)
@@ -408,8 +408,8 @@ let destruct_atom srk phi =
     end
   | `Tru ->
     let zero = mk_real srk QQ.zero in
-    `Arith_Comparison (`Eq, zero, zero)
-  | `Fls -> `Arith_Comparison (`Eq, mk_real srk QQ.zero, mk_real srk QQ.one)
+    `ArithComparison (`Eq, zero, zero)
+  | `Fls -> `ArithComparison (`Eq, mk_real srk QQ.zero, mk_real srk QQ.one)
   | _ ->
     invalid_arg @@ Format.asprintf "destruct_atom: %a is not atomic" (Formula.pp srk) phi
 

--- a/srk/src/interpretation.ml
+++ b/srk/src/interpretation.ml
@@ -131,8 +131,9 @@ let rec evaluate_term interp ?(env=Env.empty) term =
     | `App (k, []) -> real interp k
     | `App (func, args) ->
       begin match Expr.refine interp.srk (unfold_app interp func args) with
-        | `Term t ->
+        | `ArithTerm t ->
           evaluate_term interp ~env t
+        | `ArrTerm _ -> assert false
         | `Formula _ ->
           invalid_arg "evaluate_term: ill-typed function application"
       end
@@ -149,6 +150,7 @@ let rec evaluate_term interp ?(env=Env.empty) term =
       raise Divide_by_zero
     | `Binop (`Div, dividend, divisor) -> QQ.div dividend divisor
     | `Binop (`Mod, t, modulus) -> QQ.modulo t modulus
+    | `Select _ -> assert false
     | `Unop (`Floor, t) -> QQ.of_zz (QQ.floor t)
     | `Unop (`Neg, t) -> QQ.negate t
     | `Ite (cond, bthen, belse) ->
@@ -158,7 +160,7 @@ let rec evaluate_term interp ?(env=Env.empty) term =
         belse
   in
   try
-    Term.eval interp.srk f term
+    ArithTerm.eval interp.srk f term
   with Not_found ->
     invalid_arg "evaluate_term: no interpretation for constant symbol"
 
@@ -168,7 +170,7 @@ and evaluate_formula interp ?(env=Env.empty) phi =
     | `Or xs -> List.exists (fun x -> x) xs
     | `Tru -> true
     | `Fls -> false
-    | `Atom (op, s, t) ->
+    | `Atom (`Arith (op, s, t)) ->
       begin try
           let s = evaluate_term interp ~env s in
           let t = evaluate_term interp ~env t in
@@ -179,11 +181,12 @@ and evaluate_formula interp ?(env=Env.empty) phi =
           end
         with Divide_by_zero -> false
       end
+    | `Atom (`ArrEq _) -> invalid_arg "evaluate_formula: array atom"
     | `Not v -> not v
     | `Ite (cond, bthen, belse) -> if cond then bthen else belse
     | `Proposition (`App (k, [])) -> bool interp k
     | `Proposition (`App (func, args)) ->
-      begin match Expr.refine interp.srk (unfold_app interp func args) with
+      begin match Expr.refine_coarse interp.srk (unfold_app interp func args) with
         | `Formula phi ->
           evaluate_formula interp ~env phi
         | `Term _ ->
@@ -206,7 +209,7 @@ let get_context interp = interp.srk
 let select_implicant interp ?(env=Env.empty) phi =
   let srk = interp.srk in
   let rec term t =
-    match Term.destruct srk t with
+    match ArithTerm.destruct srk t with
     | `Real _ | `App (_, []) | `Var (_, _) -> (t, [])
     | `App (func, args) ->
       let (args, implicant) =
@@ -253,6 +256,7 @@ let select_implicant interp ?(env=Env.empty) phi =
         | `Neg -> mk_neg srk t_term
       in
       (term, t_impl)
+    | `Select _ -> assert false
     | `Ite (cond, bthen, belse) ->
       begin match formula cond with
         | Some implicant ->
@@ -289,7 +293,7 @@ let select_implicant interp ?(env=Env.empty) phi =
       in
       (try Some (BatList.concat (List.map f conjuncts))
        with Not_found -> None)
-    | `Atom (op, s, t) ->
+    | `Atom (`Arith (op, s, t)) ->
       let (s_term, s_impl) = term s in
       let (t_term, t_impl) = term t in
       begin
@@ -312,6 +316,7 @@ let select_implicant interp ?(env=Env.empty) phi =
           end
         with Divide_by_zero -> None
       end
+    | `Atom (`ArrEq _) -> assert false
     | `Proposition (`App (p, [])) ->
       if bool interp p then Some [phi]
       else None
@@ -371,9 +376,10 @@ let select_implicant interp ?(env=Env.empty) phi =
     | `Quantify _ -> invalid_arg "select_implicant"
   and expr x =
     match Expr.refine srk x with
-    | `Term t ->
+    | `ArithTerm t ->
       let (t_term, t_impl) = term t in
       ((t_term :> ('a,typ_fo) expr), t_impl)
+    | `ArrTerm _ -> assert false
     | `Formula phi ->
       if evaluate_formula interp ~env phi then
         match formula phi with
@@ -389,7 +395,9 @@ let select_implicant interp ?(env=Env.empty) phi =
 
 let destruct_atom srk phi =
   match Formula.destruct srk phi with
-  | `Atom (op, s, t) -> `Comparison (op, s, t)
+  | `Atom (`Arith (op, s, t)) -> `Comparison (op, s, t)
+  | `Atom (`ArrEq _) ->  invalid_arg @@ Format.asprintf 
+      "destruct_atom: %a is syntactic sugar for quantified expression" (Formula.pp srk) phi
   | `Proposition (`App (k, [])) ->
     `Literal (`Pos, `Const k)
   | `Proposition (`Var i) -> `Literal (`Pos, `Var i)

--- a/srk/src/interpretation.mli
+++ b/srk/src/interpretation.mli
@@ -69,5 +69,6 @@ val select_ite : 'a interpretation ->
 
 val destruct_atom : 'a context ->
   'a formula ->
-  [ `Comparison of ([`Lt | `Leq | `Eq] * 'a arith_term * 'a arith_term)
-  | `Literal of ([ `Pos | `Neg ] * [ `Const of symbol | `Var of int ]) ]
+  [ `Arith_Comparison of ([`Lt | `Leq | `Eq] * 'a arith_term * 'a arith_term)
+  | `Literal of ([ `Pos | `Neg ] * [ `Const of symbol | `Var of int ])
+  | `Arr_Comparison of ('a arr_term * 'a arr_term) ]

--- a/srk/src/interpretation.mli
+++ b/srk/src/interpretation.mli
@@ -44,7 +44,7 @@ val substitute : 'a interpretation -> ('a,'typ) expr -> ('a,'typ) expr
 
 val evaluate_term : 'a interpretation ->
   ?env:[`Real of QQ.t | `Bool of bool] Env.t ->
-  'a term ->
+  'a arith_term ->
   QQ.t
     
 val evaluate_formula : 'a interpretation ->
@@ -69,5 +69,5 @@ val select_ite : 'a interpretation ->
 
 val destruct_atom : 'a context ->
   'a formula ->
-  [ `Comparison of ([`Lt | `Leq | `Eq] * 'a term * 'a term)
+  [ `Comparison of ([`Lt | `Leq | `Eq] * 'a arith_term * 'a arith_term)
   | `Literal of ([ `Pos | `Neg ] * [ `Const of symbol | `Var of int ]) ]

--- a/srk/src/interpretation.mli
+++ b/srk/src/interpretation.mli
@@ -69,6 +69,6 @@ val select_ite : 'a interpretation ->
 
 val destruct_atom : 'a context ->
   'a formula ->
-  [ `Arith_Comparison of ([`Lt | `Leq | `Eq] * 'a arith_term * 'a arith_term)
+  [ `ArithComparison of ([`Lt | `Leq | `Eq] * 'a arith_term * 'a arith_term)
   | `Literal of ([ `Pos | `Neg ] * [ `Const of symbol | `Var of int ])
-  | `Arr_Comparison of ('a arr_term * 'a arr_term) ]
+  | `ArrEq of ('a arr_term * 'a arr_term) ]

--- a/srk/src/iteration.mli
+++ b/srk/src/iteration.mli
@@ -4,7 +4,7 @@ open Syntax
 module type PreDomain = sig
   type 'a t
   val pp : 'a context -> (symbol * symbol) list -> Format.formatter -> 'a t -> unit
-  val exp : 'a context -> (symbol * symbol) list -> 'a term -> 'a t -> 'a formula
+  val exp : 'a context -> (symbol * symbol) list -> 'a arith_term -> 'a t -> 'a formula
   val abstract : 'a context -> 'a TransitionFormula.t -> 'a t
 end
 

--- a/srk/src/linear.ml
+++ b/srk/src/linear.ml
@@ -4,7 +4,7 @@ open BatPervasives
 include Log.Make(struct let name = "srk.linear" end)
 
 module IntSet = SrkUtil.Int.Set
-
+module Term = ArithTerm
 module ZZVector = struct
   include Ring.MakeVector(ZZ)
 
@@ -453,6 +453,7 @@ let linterm_of srk term =
     | `Binop (`Mod, x, y) -> real (QQ.modulo (qq_of x) (nonzero_qq_of y))
     | `Unop (`Floor, x) -> real (QQ.of_zz (QQ.floor (qq_of x)))
     | `Unop (`Neg, x) -> negate x
+    | `Select _ -> assert false
     | `Ite (_, _, _) -> raise Nonlinear
   in
   Term.eval srk alg term

--- a/srk/src/linear.mli
+++ b/srk/src/linear.mli
@@ -186,11 +186,11 @@ val const_of_linterm : QQVector.t -> QQ.t option
 
 (** Convert a rational vector representing an affine term.  Raises [Nonlinear]
     if the input term is non-linear. *)
-val linterm_of : 'a context -> 'a term -> QQVector.t
+val linterm_of : 'a context -> 'a arith_term -> QQVector.t
 
 (** Convert a rational vector to an affine term.  The equation [of_linterm srk
     (linterm_of srk t) = t] must hold. *)
-val of_linterm : 'a context -> QQVector.t -> 'a term
+val of_linterm : 'a context -> QQVector.t -> 'a arith_term
 
 (** Pretty-print an affine term *)
 val pp_linterm : 'a context -> Format.formatter -> QQVector.t -> unit
@@ -204,7 +204,7 @@ val linterm_size : QQVector.t -> int
 
 (** [term_of_vec srk t vec] creates a term representation of [vec] by
    interpreting each dimension i as the term [t i]. *)
-val term_of_vec : ('a context) -> (int -> 'a term) -> QQVector.t -> 'a term
+val term_of_vec : ('a context) -> (int -> 'a arith_term) -> QQVector.t -> 'a arith_term
 
 (** Evaluate a vector by interpreting each coordinate according to the
    given interpretation (the interpretation of [const_dim] is fixed to

--- a/srk/src/nonlinear.mli
+++ b/srk/src/nonlinear.mli
@@ -32,9 +32,9 @@ val interpret : 'a context -> ('a,'b) expr -> ('a,'b) expr
 (** Compute a linear approximation of a non-linear formula. *)
 val linearize : 'a context -> 'a formula -> 'a formula
 
-val mk_log : 'a context -> 'a term -> 'a term -> 'a term
+val mk_log : 'a context -> 'a arith_term -> 'a arith_term -> 'a arith_term
 
-val mk_pow : 'a context -> 'a term -> 'a term -> 'a term
+val mk_pow : 'a context -> 'a arith_term -> 'a arith_term -> 'a arith_term
 
 (** Given a formula phi and a list of objectives [o1,...,on], find the least
     bounding interval for each objective within the feasible region defined by
@@ -42,7 +42,7 @@ val mk_pow : 'a context -> 'a term -> 'a term -> 'a term
 val optimize_box : ?context:SrkZ3.z3_context ->
   'a context ->
   'a formula ->
-  ('a term) list ->
+  ('a arith_term) list ->
   [ `Sat of Interval.t list | `Unsat | `Unknown ]
 
 
@@ -53,4 +53,4 @@ val simplify_terms_rewriter : 'a context -> 'a rewriter
 val simplify_terms : 'a context -> 'a formula -> 'a formula
 
 (** Simplify power and log terms. *)
-val simplify_term : 'a context -> 'a term -> 'a term
+val simplify_term : 'a context -> 'a arith_term -> 'a arith_term

--- a/srk/src/polyhedron.ml
+++ b/srk/src/polyhedron.ml
@@ -115,14 +115,14 @@ let mem m polyhedron =
 let of_implicant ?(admit=false) cs conjuncts =
   let srk = CS.get_context cs in
   let linearize atom = match Interpretation.destruct_atom srk atom with
-    | `Arith_Comparison (p, x, y) ->
+    | `ArithComparison (p, x, y) ->
       let t =
         V.sub (CS.vec_of_term ~admit cs y) (CS.vec_of_term ~admit cs x)
       in
       let p = match p with `Eq -> `Zero | `Leq -> `Nonneg | `Lt -> `Pos in
       P.singleton (p, t)
     | `Literal (_, _) -> top
-    | `Arr_Comparison _ -> top
+    | `ArrEq _ -> top
   in
   List.fold_left meet top (List.map linearize conjuncts)
 

--- a/srk/src/polyhedron.ml
+++ b/srk/src/polyhedron.ml
@@ -115,13 +115,14 @@ let mem m polyhedron =
 let of_implicant ?(admit=false) cs conjuncts =
   let srk = CS.get_context cs in
   let linearize atom = match Interpretation.destruct_atom srk atom with
-    | `Comparison (p, x, y) ->
+    | `Arith_Comparison (p, x, y) ->
       let t =
         V.sub (CS.vec_of_term ~admit cs y) (CS.vec_of_term ~admit cs x)
       in
       let p = match p with `Eq -> `Zero | `Leq -> `Nonneg | `Lt -> `Pos in
       P.singleton (p, t)
     | `Literal (_, _) -> top
+    | `Arr_Comparison _ -> top
   in
   List.fold_left meet top (List.map linearize conjuncts)
 

--- a/srk/src/polyhedron.ml
+++ b/srk/src/polyhedron.ml
@@ -73,14 +73,14 @@ let of_formula ?(admit=false) cs phi =
     | `Tru -> top
     | `Fls -> bottom
     | `And xs -> List.fold_left meet top xs
-    | `Atom (`Eq, x, y) ->
+    | `Atom (`Arith (`Eq, x, y)) ->
       P.singleton (`Zero, V.sub (linearize y) (linearize x))
-    | `Atom (`Leq, x, y) ->
+    | `Atom (`Arith (`Leq, x, y)) ->
       P.singleton (`Nonneg, V.sub (linearize y) (linearize x))
-    | `Atom (`Lt, x, y) ->
+    | `Atom (`Arith (`Lt, x, y)) ->
       P.singleton (`Pos, V.sub (linearize y) (linearize x))
     | `Or _ | `Not _ | `Quantify (_, _, _, _) | `Proposition _
-    | `Ite (_, _, _) ->
+    | `Ite (_, _, _) | `Atom (`ArrEq _) ->
       invalid_arg "Polyhedron.of_formula"
   in
   Formula.eval (CS.get_context cs) alg phi

--- a/srk/src/polynomial.mli
+++ b/srk/src/polynomial.mli
@@ -50,7 +50,7 @@ module QQX : sig
   val choose : int -> t
 
   (** [term_of srk t p] computes a term representing [p(t)]. *)
-  val term_of : ('a context) -> 'a term -> t -> 'a term
+  val term_of : ('a context) -> 'a arith_term -> t -> 'a arith_term
 end
 
 (** Monomials *)
@@ -100,7 +100,7 @@ module Monomial : sig
     (t -> t -> [ `Eq | `Lt | `Gt ]) ->
     (t -> t -> [ `Eq | `Lt | `Gt ])
 
-  val term_of : ('a context) -> (dim -> 'a term) -> t -> 'a term
+  val term_of : ('a context) -> (dim -> 'a arith_term) -> t -> 'a arith_term
 end
 
 (** Signature of multivariate polynmials *)
@@ -190,7 +190,7 @@ module QQXs : sig
       not linear. *)
   val vec_of : ?const:int -> t -> Linear.QQVector.t option
 
-  val term_of : ('a context) -> (Monomial.dim -> 'a term) -> t -> 'a term
+  val term_of : ('a context) -> (Monomial.dim -> 'a arith_term) -> t -> 'a arith_term
 
   (** Greatest common divisor of all coefficients. *)
   val content : t -> QQ.t

--- a/srk/src/quantifier.ml
+++ b/srk/src/quantifier.ml
@@ -197,8 +197,8 @@ let mbp_virtual_term srk interp x atoms =
   let get_vt atom =
     match Interpretation.destruct_atom srk atom with
     | `Literal (_, _) -> None
-    | `Arr_Comparison _ -> None
-    | `Arith_Comparison (op, s, t) ->
+    | `ArrEq _ -> None
+    | `ArithComparison (op, s, t) ->
       let t =
         try V.add (linterm_of srk s) (V.negate (linterm_of srk t))
         with Nonlinear -> assert false
@@ -379,8 +379,8 @@ let is_presburger_atom srk atom =
   try
     begin match Interpretation.destruct_atom srk atom with
       | `Literal (_, _) -> true
-      | `Arr_Comparison _ -> false
-      | `Arith_Comparison (op, s, t) ->
+      | `ArrEq _ -> false
+      | `ArithComparison (op, s, t) ->
         ignore (simplify_atom srk op s t);
         true
     end
@@ -703,8 +703,8 @@ let select_real_term srk interp x atoms =
   let bound_of_atom atom =
     match Interpretation.destruct_atom srk atom with
     | `Literal (_, _) 
-    | `Arr_Comparison _ -> (None, None)
-    | `Arith_Comparison (op, s, t) ->
+    | `ArrEq _ -> (None, None)
+    | `ArithComparison (op, s, t) ->
       let t = V.add (linterm_of srk s) (V.negate (linterm_of srk t)) in
 
       let (a, t') = V.pivot (dim_of_sym x) t in
@@ -793,8 +793,8 @@ let select_int_term srk interp x atoms =
       (fun delta atom ->
          match Interpretation.destruct_atom srk atom with
          | `Literal (_, _) -> delta
-         | `Arr_Comparison _ -> delta
-         | `Arith_Comparison (op, s, t) ->
+         | `ArrEq _ -> delta
+         | `ArithComparison (op, s, t) ->
            match simplify_atom srk op s t with
            | `Divides (divisor, t) | `NotDivides (divisor, t) ->
              let a = match QQ.to_zz (V.coeff (dim_of_sym x) t) with
@@ -819,8 +819,8 @@ let select_int_term srk interp x atoms =
   let bound_of_atom atom =
     match Interpretation.destruct_atom srk atom with
     | `Literal (_, _) -> `None
-    | `Arr_Comparison _ -> `None
-    | `Arith_Comparison (op, s, t) ->
+    | `ArrEq _ -> `None
+    | `ArithComparison (op, s, t) ->
       match simplify_atom srk op s t with
       | `CompareZero (op, t) ->
         begin
@@ -1883,7 +1883,7 @@ let mbp ?(dnf=false) srk exists phi =
          let (oriented_eqs, _) =
            List.filter_map (fun atom ->
                match Interpretation.destruct_atom srk atom with
-               | `Arith_Comparison (op, s, t) ->
+               | `ArithComparison (op, s, t) ->
                   begin match simplify_atom srk op s t with
                   | `CompareZero (`Eq, t) -> Some t
                   | _ -> None
@@ -2168,9 +2168,9 @@ let cover_virtual_term srk interp x atoms =
   let get_equal_term atom =
     match Interpretation.destruct_atom srk atom with
     | `Literal (_, _) -> None
-    | `Arr_Comparison _ -> None
-    | `Arith_Comparison (`Lt, _, _) -> None
-    | `Arith_Comparison (_, s, t) ->
+    | `ArrEq _ -> None
+    | `ArithComparison (`Lt, _, _) -> None
+    | `ArithComparison (_, s, t) ->
       let sval = Interpretation.evaluate_term interp s in
       let tval = Interpretation.evaluate_term interp t in
       if QQ.equal sval tval then
@@ -2190,8 +2190,8 @@ let cover_virtual_term srk interp x atoms =
   let get_vt atom =
     match Interpretation.destruct_atom srk atom with
     | `Literal (_, _) -> None
-    | `Arr_Comparison _ -> None
-    | `Arith_Comparison (_, s, t) ->
+    | `ArrEq _ -> None
+    | `ArithComparison (_, s, t) ->
       match SrkSimplify.isolate_linear srk x (mk_sub srk s t) with
       | None -> raise Nonlinear
       | Some (a, b) when QQ.lt a QQ.zero ->

--- a/srk/src/quantifier.mli
+++ b/srk/src/quantifier.mli
@@ -10,10 +10,10 @@ val simsat_forward : 'a context -> 'a formula -> [ `Sat
                                                  | `Unknown ]
 
 (** Alternating quantifier optimization *)
-val maximize : 'a context -> 'a formula -> 'a term -> [ `Bounded of QQ.t
-                                                      | `Infinity
-                                                      | `MinusInfinity
-                                                      | `Unknown ]
+val maximize : 'a context -> 'a formula -> 'a arith_term -> [ `Bounded of QQ.t
+                                                            | `Infinity
+                                                            | `MinusInfinity
+                                                            | `Unknown ]
 
 (** Quantifier eliminiation via model-based projection *)
 val qe_mbp : 'a context -> 'a formula -> 'a formula

--- a/srk/src/solvablePolynomial.ml
+++ b/srk/src/solvablePolynomial.ml
@@ -21,6 +21,8 @@ module PLM = Lts.PartialLinearMap
 
 module TF = TransitionFormula
 
+module Term = ArithTerm
+
 (* Closed forms for solvable polynomial maps with periodic rational
    eigenvalues: multi-variate polynomials with ultimately periodic
    exponential polynomial coefficients *)
@@ -711,7 +713,7 @@ let extract_affine_transformation srk wedge tr_symbols rec_terms rec_ideal =
    A_1, term_of_id.(nb_constants+size(A_1)) corresponds to the first row of
    A_2, ...).  Similarly for inequations in rec_leq. *)
 type 'a t =
-  { term_of_id : ('a term) array;
+  { term_of_id : ('a arith_term) array;
     nb_constants : int;
     block_eq : block list;
     block_leq : block list }
@@ -891,7 +893,7 @@ let extract_vector_leq srk wedge tr_symbols term_of_id base =
   let add =
     DArray.map (fun t ->
         let name = "a[" ^ (Term.show srk t) ^ "]" in
-        mk_symbol srk ~name (term_typ srk t :> typ))
+        mk_symbol srk ~name (ArithTerm.typ srk t :> typ))
       term_of_id
   in
   let delta_map =
@@ -1698,7 +1700,7 @@ module PresburgerGuard = struct
 
   let idiv_to_ite srk expr =
     match Expr.refine srk expr with
-    | `Term t -> begin match destruct_idiv srk t with
+    | `ArithTerm t -> begin match destruct_idiv srk t with
         | Some (num, den) when den < 10 ->
           let den_term = mk_real srk (QQ.of_int den) in
           let num_over_den =
@@ -1728,7 +1730,7 @@ module PresburgerGuard = struct
   let abstract_presburger_rewriter srk expr =
     match Expr.refine srk expr with
     | `Formula phi -> begin match Formula.destruct srk phi with
-        | `Atom (_, _, _) ->
+        | `Atom _ ->
           if Quantifier.is_presburger_atom srk phi then
             expr
           else
@@ -1853,7 +1855,7 @@ end
 
 type 'a dlts_abstraction =
   { dlts : PLM.t;
-    simulation : ('a term) array }
+    simulation : ('a arith_term) array }
 
 module DLTS = struct
   module VS = Linear.QQVectorSpace

--- a/srk/src/solvablePolynomial.mli
+++ b/srk/src/solvablePolynomial.mli
@@ -27,7 +27,7 @@ module PresburgerGuard : PreDomain
 (** Deterministic linear transition systems *)
 type 'a dlts_abstraction =
   { dlts : Lts.PartialLinearMap.t;
-    simulation : ('a term) array }
+    simulation : ('a arith_term) array }
 
 (** Deterministic linear transition systems *)
 module DLTS : sig

--- a/srk/src/srkApron.ml
+++ b/srk/src/srkApron.ml
@@ -2,6 +2,8 @@ open Apron
 open BatPervasives
 open Syntax
 
+module Term = ArithTerm
+
 type dim = int
 type texpr = Texpr0.t
 type lexpr = Linexpr0.t
@@ -369,6 +371,7 @@ let texpr_of_term env t =
     | `Unop (`Neg, (t, typ)) ->
       (Binop (Mul, Cst (coeff_of_qq (QQ.negate QQ.one)), t, atyp typ, Down),
        typ)
+    | `Select _ -> assert false
   in
   Texpr0.of_expr (fst (Term.eval env.Env.srk alg t))
 

--- a/srk/src/srkApron.mli
+++ b/srk/src/srkApron.mli
@@ -72,8 +72,8 @@ val rename : (symbol -> symbol) -> ('a,'abs) property -> ('a,'abs) property
 
 val lexpr_of_vec : 'a Env.t -> Linear.QQVector.t -> lexpr
 val vec_of_lexpr : 'a Env.t -> lexpr -> Linear.QQVector.t
-val texpr_of_term : 'a Env.t -> 'a term -> texpr
-val term_of_texpr : 'a Env.t -> texpr -> 'a term
+val texpr_of_term : 'a Env.t -> 'a arith_term -> texpr
+val term_of_texpr : 'a Env.t -> texpr -> 'a arith_term
 
 val tcons_geqz : texpr -> tcons
 val tcons_eqz : texpr -> tcons

--- a/srk/src/srkAst.ml
+++ b/srk/src/srkAst.ml
@@ -1,6 +1,6 @@
 module Ctx = Syntax.MakeSimplifyingContext ()
 
-type term = Ctx.term
+type term = Ctx.arith_term
 type formula = Ctx.formula
 
 let mk_quantified mkq ks phi =

--- a/srk/src/srkSimplify.mli
+++ b/srk/src/srkSimplify.mli
@@ -5,15 +5,15 @@ module RationalTerm : sig
   type 'a rt_context
   type 'a t
   val mk_context : 'a context -> 'a rt_context
-  val of_term : 'a rt_context -> 'a term -> 'a t
-  val term_of : 'a rt_context -> 'a t -> 'a term
+  val of_term : 'a rt_context -> 'a arith_term -> 'a t
+  val term_of : 'a rt_context -> 'a t -> 'a arith_term
 end
 
 val simplify_terms_rewriter : 'a context -> 'a rewriter
 
 val simplify_terms : 'a context -> 'a formula -> 'a formula
 
-val simplify_term : 'a context -> 'a term -> 'a term
+val simplify_term : 'a context -> 'a arith_term -> 'a arith_term
 
 (** Purify function applications in a ground formula: replace each function
     application within a formula with a fresh symbol, and return both the
@@ -31,7 +31,7 @@ val simplify_conjunction : 'a context -> 'a formula list -> 'a formula list
 (** Given a term [t] and a constant symbol [x], find a coefficient [a]
    and a term [s] such that [t] is equal to [a*x + s] ([a] may be 0).
    Return [None] if this is not possible (e.g., the term [x*x]). *)
-val isolate_linear : 'a context -> symbol -> 'a term -> (QQ.t * 'a term) option
+val isolate_linear : 'a context -> symbol -> 'a arith_term -> (QQ.t * 'a arith_term) option
 
 (** Formula simplification given in Isil Dillig, Thomas Dillig, Alex
    Aiken: "Small formulas for large programs: on-line constraint
@@ -58,7 +58,7 @@ val purify_floor : 'a context ->
 val eliminate_floor : 'a context -> 'a formula -> 'a formula
 
 (** Simplify an atomic formula that consists of a binary operation of integers. *)
-val simplify_integer_atom : 'a context -> [`Eq | `Leq | `Lt ] -> 'a term -> 'a term ->
+val simplify_integer_atom : 'a context -> [`Eq | `Leq | `Lt ] -> 'a arith_term -> 'a arith_term ->
    [ `CompareZero of [ `Eq | `Leq | `Lt ] * Linear.QQVector.t
       | `Divides of ZZ.t * Linear.QQVector.t
       | `NotDivides of ZZ.t * Linear.QQVector.t ]

--- a/srk/src/srkSmtlib2.ml
+++ b/srk/src/srkSmtlib2.ml
@@ -137,7 +137,8 @@ module MakeSMT2Srk(C : sig type t val context : t Syntax.context end) = struct
   type 'a gexpr = ('a, Syntax.typ_fo) Syntax.expr
   let rec expr_of_smt of_symbol t =
     let formula_of = formula_of_smt of_symbol in
-    let term_of = term_of_smt of_symbol in
+    let aterm_of = aterm_of_smt of_symbol in
+    let arrterm_of = arrterm_of_smt of_symbol in
     let left_assoc f init args = List.fold_left f init args in
     let chain f init args =
       let rec go acc x = function
@@ -198,7 +199,7 @@ module MakeSMT2Srk(C : sig type t val context : t Syntax.context end) = struct
          | [] -> assert false
          | _ :: [] -> assert false
          | _ ->
-           let terms = List.map term_of terms in
+           let terms = List.map aterm_of terms in
            let f x y phis = (mk_eq srk x y) :: phis in
            (mk_and srk (chain f [] terms) :> 'a gexpr)
          end
@@ -206,7 +207,7 @@ module MakeSMT2Srk(C : sig type t val context : t Syntax.context end) = struct
         begin match terms with
         | [] -> assert false
         | _ ->
-          let terms = List.map term_of terms in
+          let terms = List.map aterm_of terms in
           let f x y phis = (mk_not srk (mk_eq srk x y)) :: phis in
           (mk_and srk (pair_wise f [] terms) :> 'a gexpr)
         end
@@ -222,44 +223,44 @@ module MakeSMT2Srk(C : sig type t val context : t Syntax.context end) = struct
       | "+" ->
         begin match terms with
         | [] -> assert false
-        | [t] -> (term_of t :> 'a gexpr)
-        | _ -> (mk_add srk (List.map term_of terms) :> 'a gexpr)
+        | [t] -> (aterm_of t :> 'a gexpr)
+        | _ -> (mk_add srk (List.map aterm_of terms) :> 'a gexpr)
         end
       | "-" -> (* neg or (sub left assoc) *)
         begin match terms with
         | [] -> assert false
-        | [t] -> (mk_neg srk (term_of t) :> 'a gexpr)
+        | [t] -> (mk_neg srk (aterm_of t) :> 'a gexpr)
         | _ ->
-          let terms = List.map term_of terms in
+          let terms = List.map aterm_of terms in
           (left_assoc (mk_sub srk) (List.hd terms) (List.tl terms) :> 'a gexpr)
         end
       | "*" ->
         begin match terms with
         | [] -> assert false
-        | [t] -> (term_of t :> 'a gexpr)
-        | _ -> (mk_mul srk (List.map term_of terms) :> 'a gexpr)
+        | [t] -> (aterm_of t :> 'a gexpr)
+        | _ -> (mk_mul srk (List.map aterm_of terms) :> 'a gexpr)
         end
       | "mod" ->
         begin match terms with
-        | [x; y] -> (mk_mod srk (term_of x) (term_of y) :> 'a gexpr)
+        | [x; y] -> (mk_mod srk (aterm_of x) (aterm_of y) :> 'a gexpr)
         | _ -> assert false
         end
       | "div" ->
         begin match terms with
-        | [x; y] -> (mk_idiv srk (term_of x) (term_of y) :> 'a gexpr)
+        | [x; y] -> (mk_idiv srk (aterm_of x) (aterm_of y) :> 'a gexpr)
         | _ -> assert false
         end
       | "abs" ->
         begin match terms with
         | [x] ->
-          let x = term_of x in
+          let x = aterm_of x in
           (mk_ite srk (mk_lt srk x (mk_int srk 0)) (mk_neg srk x) x :> 'a gexpr)
         | _ -> assert false
         end
       | "<" -> (* chainable *)
          begin match terms with
          | _ :: _ :: _ ->
-           let terms = List.map term_of terms in
+           let terms = List.map aterm_of terms in
            let f x y phis = (mk_lt srk x y) :: phis in
            (mk_and srk (chain f [] terms) :> 'a gexpr)
          | _ -> assert false
@@ -267,7 +268,7 @@ module MakeSMT2Srk(C : sig type t val context : t Syntax.context end) = struct
       | ">" ->
          begin match terms with
          | _ :: _ :: _ ->
-           let terms = List.rev_map term_of terms in
+           let terms = List.rev_map aterm_of terms in
            let f x y phis = (mk_lt srk x y) :: phis in
            (mk_and srk (chain f [] terms) :> 'a gexpr)
          | _ -> assert false
@@ -275,7 +276,7 @@ module MakeSMT2Srk(C : sig type t val context : t Syntax.context end) = struct
       | "<=" ->
          begin match terms with
          | _ :: _ :: _ ->
-           let terms = List.map term_of terms in
+           let terms = List.map aterm_of terms in
            let f x y phis = (mk_leq srk x y) :: phis in
            (mk_and srk (chain f [] terms) :> 'a gexpr)
          | _ -> assert false
@@ -283,30 +284,30 @@ module MakeSMT2Srk(C : sig type t val context : t Syntax.context end) = struct
       | ">=" ->
          begin match terms with
          | _ :: _ :: _ ->
-           let terms = List.rev_map term_of terms in
+           let terms = List.rev_map aterm_of terms in
            let f x y phis = (mk_leq srk x y) :: phis in
            (mk_and srk (chain f [] terms) :> 'a gexpr)
          | _ -> assert false
          end
       | "/" ->
         begin match terms with
-        | [x; y] -> (mk_div srk (term_of x) (term_of y) :> 'a gexpr)
+        | [x; y] -> (mk_div srk (aterm_of x) (aterm_of y) :> 'a gexpr)
         | _ -> assert false
         end
       | "to_real" -> (* maybe this should be unsupported rather than being a noop in srk *)
         begin match terms with
-        | [t] -> (term_of t :> 'a gexpr)
+        | [t] -> (aterm_of t :> 'a gexpr)
         | _ -> assert false
         end
       | "to_int" ->
         begin match terms with
-        | [t] -> (mk_floor srk (term_of t) :> 'a gexpr)
+        | [t] -> (mk_floor srk (aterm_of t) :> 'a gexpr)
         | _ -> assert false
         end
       | "is_int" ->
         begin match terms with
         | [t] ->
-          let t = term_of t in
+          let t = aterm_of t in
           (mk_eq srk (mk_floor srk t) t :> 'a gexpr)
         | _ -> assert false
         end
@@ -317,20 +318,22 @@ module MakeSMT2Srk(C : sig type t val context : t Syntax.context end) = struct
           begin match typ_symbol srk sym with
           | `TyBool
           | `TyInt
-          | `TyReal -> (mk_const srk (of_symbol srk_sym) :> 'a gexpr)
+          | `TyReal 
+          | `TyArr -> (mk_const srk (of_symbol srk_sym) :> 'a gexpr)
           | `TyFun _ -> invalid_arg "Unexpected function symbol"
           end
         | _ ->
           let sym = of_symbol srk_sym in
           match typ_symbol srk sym with
-          | `TyBool | `TyInt | `TyReal -> invalid_arg "Unexpected function application: Non-functional symbol"
+          | `TyBool | `TyInt | `TyReal | `TyArr -> invalid_arg "Unexpected function application: Non-functional symbol"
           | `TyFun (args_typ, _) ->
             if (List.length terms) != (List.length args_typ) then invalid_arg "Unexpected function application: arity mistmatch" else
             let args =
               List.map2 (fun term typ ->
                 match typ with
                 | `TyBool -> (formula_of term :> 'a gexpr)
-                | _ -> (term_of term :> 'a gexpr)
+                | `TyInt | `TyReal -> (aterm_of term :> 'a gexpr)
+                | `TyArr -> (arrterm_of term :> 'a gexpr)
               ) terms args_typ
             in
             (mk_app srk sym args :> 'a gexpr)
@@ -339,7 +342,7 @@ module MakeSMT2Srk(C : sig type t val context : t Syntax.context end) = struct
     | App ((("divisible", [Num n]), None), terms) ->
       begin match terms with
       | [t] ->
-        let t = term_of t in
+        let t = aterm_of t in
         let sym = mk_symbol srk `TyInt in
         let n = mk_zz srk n in
         (mk_exists_const srk sym (mk_eq srk t (mk_mul srk [n; mk_const srk sym])) :> 'a gexpr)
@@ -350,10 +353,14 @@ module MakeSMT2Srk(C : sig type t val context : t Syntax.context end) = struct
     | Exists (vars, t) -> invalid_arg "Unsupported" *)
     | App _ -> invalid_arg "Unknown function name"
     | _ -> invalid_arg "Match and attribute statments are not supported"
-  and term_of_smt of_symbol t =
+  and aterm_of_smt of_symbol t =
     match Syntax.Expr.refine srk (expr_of_smt of_symbol t) with
-    | `Term t -> t
-    | _ -> invalid_arg "Term expected"
+    | `ArithTerm t -> t
+    | _ -> invalid_arg "Arithmatic Term expected"
+  and arrterm_of_smt of_symbol t =
+    match Syntax.Expr.refine srk (expr_of_smt of_symbol t) with
+    | `ArrTerm t -> t
+    | _ -> invalid_arg "Array Term expected"
   and formula_of_smt of_symbol t =
     match Syntax.Expr.refine srk (expr_of_smt of_symbol t) with
     | `Formula phi -> phi
@@ -397,7 +404,7 @@ module MakeSMT2Srk(C : sig type t val context : t Syntax.context end) = struct
   (* functions are debruijn indexed *)
   let model_of_smt of_symbol (m : model) =
     let open Syntax in
-    let term_of_smt of_sym t = term_of_smt of_sym t in
+    (*let term_of_smt of_sym t = term_of_smt of_sym t in*)
     let formula_of_smt of_sym phi = formula_of_smt of_sym phi in
     List.map (fun (sym, formals, ret_typ, def) ->
       let sym = of_symbol sym in
@@ -413,10 +420,11 @@ module MakeSMT2Srk(C : sig type t val context : t Syntax.context end) = struct
         | `TyInt, `TyInt
         | `TyReal, `TyReal ->
           assert (formals = []);
-          begin match Term.destruct srk (term_of_smt of_symbol def) with
+          begin match ArithTerm.destruct srk (aterm_of_smt of_symbol def) with
           | `Real qq -> `Real qq
           | _ -> invalid_arg "Mismatch between model and symbol definitions 2"
           end
+        | `TyArr, `TyArr -> assert false (*TODO*)
         | `TyFun (args, `TyInt), `TyInt
         | `TyFun (args, `TyReal), `TyReal
         | `TyFun (args, `TyBool), `TyBool ->
@@ -441,7 +449,10 @@ module MakeSMT2Srk(C : sig type t val context : t Syntax.context end) = struct
           let def =
             match (typ_symbol srk sym) with
             | `TyFun (_, `TyBool) -> (formula_of_smt of_symbol def :> 'a gexpr)
-            | _ -> (term_of_smt of_symbol def :> 'a gexpr)
+            | `TyFun (_, `TyInt) 
+            | `TyFun(_, `TyReal) -> (aterm_of_smt of_symbol def :> 'a gexpr)
+            | `TyFun(_, `TyArr) -> (arrterm_of_smt of_symbol def :> 'a gexpr)
+            | _ -> assert false
           in
           let res =
             substitute_const srk (fun sym ->

--- a/srk/src/srkSmtlib2.mli
+++ b/srk/src/srkSmtlib2.mli
@@ -18,7 +18,8 @@ val string_parse_model : string -> model
 val typ_of_sort : sort -> Syntax.typ
 
 module MakeSMT2Srk(C : sig type t val context : t Syntax.context end) : sig
-  val term_of_smt : (symbol -> Syntax.symbol) -> term -> C.t Syntax.term
+  val aterm_of_smt : (symbol -> Syntax.symbol) -> term -> C.t Syntax.arith_term
+  val arrterm_of_smt : (symbol -> Syntax.symbol) -> term -> C.t Syntax.arr_term
   val formula_of_smt : (symbol -> Syntax.symbol) -> term -> C.t Syntax.formula
   val expr_of_smt : (symbol -> Syntax.symbol) -> term -> (C.t, Syntax.typ_fo) Syntax.expr
 

--- a/srk/src/srkSmtlib2.mli
+++ b/srk/src/srkSmtlib2.mli
@@ -18,8 +18,8 @@ val string_parse_model : string -> model
 val typ_of_sort : sort -> Syntax.typ
 
 module MakeSMT2Srk(C : sig type t val context : t Syntax.context end) : sig
-  val aterm_of_smt : (symbol -> Syntax.symbol) -> term -> C.t Syntax.arith_term
-  val arrterm_of_smt : (symbol -> Syntax.symbol) -> term -> C.t Syntax.arr_term
+  val arith_term_of_smt : (symbol -> Syntax.symbol) -> term -> C.t Syntax.arith_term
+  val arr_term_of_smt : (symbol -> Syntax.symbol) -> term -> C.t Syntax.arr_term
   val formula_of_smt : (symbol -> Syntax.symbol) -> term -> C.t Syntax.formula
   val expr_of_smt : (symbol -> Syntax.symbol) -> term -> (C.t, Syntax.typ_fo) Syntax.expr
 

--- a/srk/src/srkZ3.ml
+++ b/srk/src/srkZ3.ml
@@ -328,6 +328,7 @@ let of_z3 context sym_of_decl expr =
     | `Atom (`Eq, s, t) ->
       begin match Expr.refine context s, Expr.refine context t with
         | `ArithTerm s, `ArithTerm t -> (mk_eq context s t :> 'a gexpr)
+        | `ArrTerm a, `ArrTerm b -> (mk_arr_eq context a b :> 'a gexpr)
         | `Formula phi, `Formula psi ->
           (mk_or context [mk_and context [phi; psi];
                           mk_and context [mk_not context phi;

--- a/srk/src/srkZ3.ml
+++ b/srk/src/srkZ3.ml
@@ -13,8 +13,9 @@ type 'a open_expr = [
   | `Var of int * typ_fo
   | `Add of 'a list
   | `Mul of 'a list
-  | `Binop of [ `Div | `Mod ] * 'a * 'a
+  | `Binop of [ `Div | `Mod | `Select ] * 'a * 'a
   | `Unop of [ `Floor | `Neg ] * 'a
+  | `Store of 'a * 'a * 'a
   | `Tru
   | `Fls
   | `And of 'a list
@@ -47,12 +48,15 @@ let typ_of_sort sort =
   | REAL_SORT -> `TyReal
   | INT_SORT -> `TyInt
   | BOOL_SORT -> `TyBool
+  | ARRAY_SORT -> `TyArr
   | _ -> invalid_arg "typ_of_sort"
 
-let sort_of_typ z3 = function
+let rec sort_of_typ z3 = function
   | `TyInt -> Z3.Arithmetic.Integer.mk_sort z3
   | `TyReal -> Z3.Arithmetic.Real.mk_sort z3
   | `TyBool -> Z3.Boolean.mk_sort z3
+  | `TyArr -> 
+    Z3.Z3Array.mk_sort z3 (sort_of_typ z3 `TyInt) (sort_of_typ z3 `TyInt)
 
 let rec eval alg ast =
   let open Z3 in
@@ -73,6 +77,9 @@ let rec eval alg ast =
       | (OP_TO_REAL, [x]) -> x
       | (OP_TO_INT, [x]) -> alg (`Unop (`Floor, x))
 
+      | (OP_STORE, [a; i; v]) -> alg (`Store (a, i, v))
+      | (OP_SELECT, [a; i]) -> alg (`Binop(`Select, a, i))
+      
       | (OP_TRUE, []) -> alg `Tru
       | (OP_FALSE, []) -> alg `Fls
       | (OP_AND, args) -> alg (`And args)
@@ -168,7 +175,7 @@ let z3_of_symbol z3 sym = Z3.Symbol.mk_int z3 (int_of_symbol sym)
 
 let decl_of_symbol z3 srk sym =
   let (param_sorts, return_sort) = match typ_symbol srk sym with
-    | `TyInt | `TyReal | `TyBool ->
+    | `TyInt | `TyReal | `TyBool | `TyArr ->
       invalid_arg "decl_of_symbol: not a function symbol"
     | `TyFun (params, return) ->
       (List.map (sort_of_typ z3) params, sort_of_typ z3 return)
@@ -177,11 +184,40 @@ let decl_of_symbol z3 srk sym =
   Z3.FuncDecl.mk_func_decl z3 z3sym param_sorts return_sort
 
 let rec z3_of_expr srk z3 expr =
-  match Expr.refine srk expr with
+  match Expr.refine_coarse srk expr with
   | `Term t -> z3_of_term srk z3 t
   | `Formula phi -> z3_of_formula srk z3 phi
 
-and z3_of_term (srk : 'a context) z3 (term : 'a term) =
+and z3_of_term srk z3 term =
+  match Term.refine srk term with
+  | `ArithTerm t -> z3_of_arith_term srk z3 t
+  | `ArrTerm t -> z3_of_arr_term srk z3 t
+
+and z3_of_arr_term (srk : 'a context) z3 (term : 'a arr_term) =
+  let alg = function
+    | `App (sym, []) ->
+      let sort = match typ_symbol srk sym with
+        | `TyArr -> sort_of_typ z3 `TyArr
+        | `TyInt | `TyReal | `TyBool | `TyFun (_,_) ->
+          invalid_arg "z3_of_arr_term: ill-typed application"
+      in
+      let decl = Z3.FuncDecl.mk_const_decl z3 (z3_of_symbol z3 sym) sort in
+      Z3.Expr.mk_const_f z3 decl
+
+    | `App (func, args) ->
+      let decl = decl_of_symbol z3 srk func in
+      Z3.Expr.mk_app z3 decl (List.map (z3_of_expr srk z3) args)
+
+    | `Var (i, `TyArr) ->
+      Z3.Quantifier.mk_bound z3 i (sort_of_typ z3 `TyArr)
+    | `Store (a, i, v) -> 
+      Z3.Z3Array.mk_store z3 a (z3_of_arith_term srk z3 i) (z3_of_arith_term srk z3 v)
+    | `Ite (cond, bthen, belse) ->
+      Z3.Boolean.mk_ite z3 (z3_of_formula srk z3 cond) bthen belse
+  in
+  ArrTerm.eval srk alg term
+
+and z3_of_arith_term (srk : 'a context) z3 (term : 'a arith_term) =
   let alg = function
     | `Real qq ->
       begin match QQ.to_zz qq with
@@ -192,7 +228,7 @@ and z3_of_term (srk : 'a context) z3 (term : 'a term) =
       let sort = match typ_symbol srk sym with
         | `TyInt -> sort_of_typ z3 `TyInt
         | `TyReal -> sort_of_typ z3 `TyReal
-        | `TyBool | `TyFun (_,_) ->
+        | `TyBool | `TyFun (_,_) | `TyArr ->
           invalid_arg "z3_of.term: ill-typed application"
       in
       let decl = Z3.FuncDecl.mk_const_decl z3 (z3_of_symbol z3 sym) sort in
@@ -202,8 +238,6 @@ and z3_of_term (srk : 'a context) z3 (term : 'a term) =
       let decl = decl_of_symbol z3 srk func in
       Z3.Expr.mk_app z3 decl (List.map (z3_of_expr srk z3) args)
 
-    | `Var (_, `TyFun (_, _)) | `Var (_, `TyBool) ->
-      invalid_arg "z3_of.term: variable"
     | `Var (i, `TyInt) ->
       Z3.Quantifier.mk_bound z3 i (sort_of_typ z3 `TyInt)
     | `Var (i, `TyReal) ->
@@ -214,13 +248,15 @@ and z3_of_term (srk : 'a context) z3 (term : 'a term) =
     | `Binop (`Mod, s, t) -> Z3.Arithmetic.Integer.mk_mod z3 s t
     | `Unop (`Floor, t) -> Z3. Arithmetic.Real.mk_real2int z3 t
     | `Unop (`Neg, t) -> Z3.Arithmetic.mk_unary_minus z3 t
+    | `Select (a, i) -> Z3.Z3Array.mk_select z3 (z3_of_arr_term srk z3 a) i
     | `Ite (cond, bthen, belse) ->
       Z3.Boolean.mk_ite z3 (z3_of_formula srk z3 cond) bthen belse
   in
-  Term.eval srk alg term
+  ArithTerm.eval srk alg term
 
 and z3_of_formula srk z3 =
-  let of_term = z3_of_term srk z3 in
+  let of_arith_term = z3_of_arith_term srk z3 in
+  let of_arr_term = z3_of_arr_term srk z3 in
   let alg = function
     | `Tru -> Z3.Boolean.mk_true z3
     | `Fls -> Z3.Boolean.mk_false z3
@@ -239,9 +275,10 @@ and z3_of_formula srk z3 =
     | `Not phi -> Z3.Boolean.mk_not z3 phi
     | `Quantify (qt, name, typ, phi) ->
       mk_quantified z3 qt ~name typ phi
-    | `Atom (`Eq, s, t) -> Z3.Boolean.mk_eq z3 (of_term s) (of_term t)
-    | `Atom (`Leq, s, t) -> Z3.Arithmetic.mk_le z3 (of_term s) (of_term t)
-    | `Atom (`Lt, s, t) -> Z3.Arithmetic.mk_lt z3 (of_term s) (of_term t)
+    | `Atom (`Arith (`Eq, s, t)) -> Z3.Boolean.mk_eq z3 (of_arith_term s) (of_arith_term t)
+    | `Atom (`Arith (`Leq, s, t)) -> Z3.Arithmetic.mk_le z3 (of_arith_term s) (of_arith_term t)
+    | `Atom (`Arith (`Lt, s, t)) -> Z3.Arithmetic.mk_lt z3 (of_arith_term s) (of_arith_term t)
+    | `Atom (`ArrEq (s, t)) -> Z3.Boolean.mk_eq z3 (of_arr_term s) (of_arr_term t)
     | `Proposition (`Var i) ->
       Z3.Quantifier.mk_bound z3 i (sort_of_typ z3 `TyBool)
     | `Proposition (`App (p, [])) ->
@@ -260,16 +297,9 @@ and z3_of_formula srk z3 =
 
 type 'a gexpr = ('a, typ_fo) Syntax.expr
 let of_z3 context sym_of_decl expr =
-  let term expr =
-    match Expr.refine context expr with
-    | `Term t -> t
-    | _ -> invalid_arg "of_z3.term"
-  in
-  let formula expr =
-    match Expr.refine context expr with
-    | `Formula phi -> phi
-    | _ -> invalid_arg "of_z3.formula"
-  in
+  let arith_term = Syntax.Expr.arith_term_of context in
+  let arr_term = Syntax.Expr.arr_term_of context in
+  let formula = Syntax.Expr.formula_of context in
   let alg : (('a, typ_fo) Syntax.expr) open_expr -> ('a, typ_fo) Syntax.expr =
     function
     | `Real qq -> (mk_real context qq :> 'a gexpr)
@@ -277,12 +307,14 @@ let of_z3 context sym_of_decl expr =
     | `App (decl, args) ->
       let const_sym = sym_of_decl decl in
       mk_app context const_sym args
-    | `Add sum -> (mk_add context (List.map term sum) :> 'a gexpr)
-    | `Mul product -> (mk_mul context (List.map term product) :> 'a gexpr)
-    | `Binop (`Div, s, t) -> (mk_div context (term s) (term t) :> 'a gexpr)
-    | `Binop (`Mod, s, t) -> (mk_mod context (term s) (term t) :> 'a gexpr)
-    | `Unop (`Floor, t) -> (mk_floor context (term t) :> 'a gexpr)
-    | `Unop (`Neg, t) -> (mk_neg context (term t) :> 'a gexpr)
+    | `Add sum -> (mk_add context (List.map arith_term sum) :> 'a gexpr)
+    | `Mul product -> (mk_mul context (List.map arith_term product) :> 'a gexpr)
+    | `Binop (`Div, s, t) -> (mk_div context (arith_term s) (arith_term t) :> 'a gexpr)
+    | `Binop (`Mod, s, t) -> (mk_mod context (arith_term s) (arith_term t) :> 'a gexpr) 
+    | `Binop (`Select, a, i) -> (mk_select context (arr_term a) (arith_term i) :> 'a gexpr) 
+    | `Unop (`Floor, t) -> (mk_floor context (arith_term t) :> 'a gexpr)
+    | `Unop (`Neg, t) -> (mk_neg context (arith_term t) :> 'a gexpr)
+    | `Store (a, i, v) -> (mk_store context (arr_term a) (arith_term i) (arith_term v) :> 'a gexpr)
     | `Tru -> (mk_true context :> 'a gexpr)
     | `Fls -> (mk_false context :> 'a gexpr)
     | `And conjuncts ->
@@ -295,7 +327,7 @@ let of_z3 context sym_of_decl expr =
       (mk_forall context ~name:name typ (formula phi) :> 'a gexpr)
     | `Atom (`Eq, s, t) ->
       begin match Expr.refine context s, Expr.refine context t with
-        | `Term s, `Term t -> (mk_eq context s t :> 'a gexpr)
+        | `ArithTerm s, `ArithTerm t -> (mk_eq context s t :> 'a gexpr)
         | `Formula phi, `Formula psi ->
           (mk_or context [mk_and context [phi; psi];
                           mk_and context [mk_not context phi;
@@ -303,8 +335,8 @@ let of_z3 context sym_of_decl expr =
            :> 'a gexpr)
         | _, _ -> invalid_arg "of_z3: equal"
       end
-    | `Atom (`Leq, s, t) -> (mk_leq context (term s) (term t) :> 'a gexpr)
-    | `Atom (`Lt, s, t) -> (mk_lt context (term s) (term t) :> 'a gexpr)
+    | `Atom (`Leq, s, t) -> (mk_leq context (arith_term s) (arith_term t) :> 'a gexpr)
+    | `Atom (`Lt, s, t) -> (mk_lt context (arith_term s) (arith_term t) :> 'a gexpr)
     | `Ite (cond, bthen, belse) -> mk_ite context (formula cond) bthen belse
   in
   eval alg expr
@@ -317,7 +349,7 @@ let sym_of_decl decl =
   symbol_of_int (Z3.Symbol.get_int sym)
 
 let term_of_z3 context term =
-  match Expr.refine context (of_z3 context sym_of_decl term) with
+  match Expr.refine_coarse context (of_z3 context sym_of_decl term) with
   | `Term t -> t
   | _ -> invalid_arg "term_of"
 
@@ -394,6 +426,7 @@ module Solver = struct
         | Some x -> `Bool (bool_val x)
         | None -> assert false
       end
+    | `TyArr -> assert false (* TODO: intepretations for arrays *)
     | `TyFun (params, _) ->
       let decl = decl_of_symbol z3 srk sym in
       let finterp = match Z3.Model.get_func_interp m decl with
@@ -409,7 +442,7 @@ module Solver = struct
       in
       let mk_eq x y = (* type-generic equality *)
         match Expr.refine srk x, Expr.refine srk y with
-        | `Term x, `Term y ->
+        | `ArithTerm x, `ArithTerm y ->
           (mk_eq srk x y :> ('a, 'typ_fo) Syntax.expr)
         | `Formula x, `Formula y ->
           (mk_iff srk x y :> ('a, 'typ_fo) Syntax.expr)
@@ -482,7 +515,7 @@ let optimize_box ?(context=Z3.mk_context []) srk phi objectives =
   set_parameters opt params;
   add opt [z3_of_formula srk z3 phi];
   let mk_handles t =
-    let z3t = z3_of_term srk z3 t in
+    let z3t = z3_of_arith_term srk z3 t in
     (minimize opt z3t, maximize opt z3t)
   in
   let handles = List.map mk_handles objectives in
@@ -556,7 +589,7 @@ let load_smtlib2 ?(context=Z3.mk_context []) srk str =
   in
   Z3.AST.ASTVector.to_expr_list ast
   |> List.map (fun expr ->
-         match Expr.refine srk (of_z3 srk sym_of_decl expr) with
+         match Expr.refine_coarse srk (of_z3 srk sym_of_decl expr) with
          | `Formula phi -> phi
          | `Term _ -> invalid_arg "load_smtlib2")
   |> mk_and srk

--- a/srk/src/srkZ3.mli
+++ b/srk/src/srkZ3.mli
@@ -12,8 +12,9 @@ type 'a open_expr = [
   | `Var of int * typ_fo
   | `Add of 'a list
   | `Mul of 'a list
-  | `Binop of [ `Div | `Mod ] * 'a * 'a
+  | `Binop of [ `Div | `Mod | `Select ] * 'a * 'a
   | `Unop of [ `Floor | `Neg ] * 'a
+  | `Store of 'a * 'a * 'a
   | `Tru
   | `Fls
   | `And of 'a list
@@ -25,6 +26,8 @@ type 'a open_expr = [
 ]
 
 val z3_of_term : 'a context -> z3_context -> 'a term -> z3_expr
+val z3_of_arith_term : 'a context -> z3_context -> 'a arith_term -> z3_expr
+val z3_of_arr_term : 'a context -> z3_context -> 'a arr_term -> z3_expr
 val z3_of_formula : 'a context -> z3_context -> 'a formula -> z3_expr
 val z3_of_expr : 'a context -> z3_context -> ('a,typ_fo) expr -> z3_expr
 
@@ -83,7 +86,7 @@ val mk_solver : ?context:z3_context -> ?theory:string -> 'a context -> 'a Solver
 val optimize_box : ?context:z3_context ->
   'a context ->
   'a formula ->
-  ('a term) list ->
+  ('a arith_term) list ->
   [ `Sat of Interval.t list | `Unsat | `Unknown ]
 
 (** Quantifier elimination *)

--- a/srk/src/syntax.ml
+++ b/srk/src/syntax.ml
@@ -1,16 +1,19 @@
 open BatPervasives
 open BatHashcons
 
-type typ_fo = [ `TyInt | `TyReal | `TyBool ] [@@ deriving ord]
+type typ_fo = [ `TyInt | `TyReal | `TyBool  | `TyArr ] [@@ deriving ord]
 
 type typ = [
   | `TyInt
   | `TyReal
   | `TyBool
+  | `TyArr
   | `TyFun of (typ_fo list * typ_fo)
 ]
 
 type typ_arith = [ `TyInt | `TyReal ]
+type typ_term = [ `TyInt | `TyReal | `TyArr ]
+type typ_arr = [ `TyArr ]
 type typ_bool = [ `TyBool ]
 type 'a typ_fun = [ `TyFun of (typ_fo list) * 'a ]
 
@@ -21,11 +24,13 @@ let pp_typ_fo formatter = function
   | `TyReal -> Format.pp_print_string formatter "real"
   | `TyInt -> Format.pp_print_string formatter "int"
   | `TyBool -> Format.pp_print_string formatter "bool"
+  | `TyArr -> Format.pp_print_string formatter "array"
 
 let pp_typ formatter = function
   | `TyInt -> pp_typ_fo formatter `TyInt
   | `TyReal -> pp_typ_fo formatter `TyReal
   | `TyBool -> pp_typ_fo formatter `TyBool
+  | `TyArr -> pp_typ_fo formatter `TyArr
   | `TyFun (dom, cod) ->
     let pp_sep formatter () = Format.fprintf formatter "@ * " in
     Format.fprintf formatter "(@[%a@ -> %a@])"
@@ -45,6 +50,7 @@ type label =
   | Eq
   | Leq
   | Lt
+  | ArrEq
   | App of symbol
   | Var of int * typ_fo
   | Add
@@ -55,10 +61,14 @@ type label =
   | Neg
   | Real of QQ.t
   | Ite
+  | Store
+  | Select
 
 type sexpr = Node of label * ((sexpr hobj) list) * typ_fo
 type ('a,'typ) expr = sexpr hobj
-type 'a term = ('a, typ_arith) expr
+type 'a term = ('a, typ_term) expr
+type 'a arith_term = ('a, typ_arith) expr
+type 'a arr_term = ('a, typ_arr) expr
 type 'a formula = ('a, typ_bool) expr
 
 let compare_expr s t = Stdlib.compare s.tag t.tag
@@ -171,12 +181,33 @@ let rec flatten_sexpr label sexpr =
 type ('a, 'b) open_term = [
   | `Real of QQ.t
   | `App of symbol * (('b, typ_fo) expr list)
+  | `Var of int * typ_term
+  | `Add of 'a list
+  | `Mul of 'a list
+  | `Binop of [ `Div | `Mod ] * 'a * 'a
+  | `Unop of [ `Floor | `Neg ] * 'a
+  | `Ite of ('b formula) * 'a * 'a
+  | `Select of 'a * 'a
+  | `Store of 'a * 'a * 'a
+]
+
+type ('a,'b) open_arith_term = [
+  | `Real of QQ.t
+  | `App of symbol * (('b, typ_fo) expr list)
   | `Var of int * typ_arith
   | `Add of 'a list
   | `Mul of 'a list
   | `Binop of [ `Div | `Mod ] * 'a * 'a
   | `Unop of [ `Floor | `Neg ] * 'a
   | `Ite of ('b formula) * 'a * 'a
+  | `Select of 'b arr_term * 'a
+]
+
+type ('a,'b) open_arr_term = [
+  | `App of symbol * (('b, typ_fo) expr list)
+  | `Var of int * typ_arr
+  | `Ite of ('b formula) * 'a * 'a
+  | `Store of 'a * 'b arith_term * 'b arith_term
 ]
 
 type ('a,'b) open_formula = [
@@ -186,11 +217,15 @@ type ('a,'b) open_formula = [
   | `Or of 'a list
   | `Not of 'a
   | `Quantify of [`Exists | `Forall] * string * typ_fo * 'a
-  | `Atom of [`Eq | `Leq | `Lt] * 'b term * 'b term
-  | `Ite of 'a * 'a * 'a
+  | `Atom of 
+      [ `Arith of [`Eq | `Leq | `Lt] * ('b arith_term) * ('b arith_term)
+      | `ArrEq of 'b arr_term * 'b arr_term ]
   | `Proposition of [ `Var of int
-                    | `App of symbol * ('b, typ_fo) expr list ]
+                    | `App of symbol * (('b, typ_fo) expr) list ]
+  | `Ite of 'a * 'a * 'a
 ]
+
+
 
 exception Quit
 
@@ -245,6 +280,7 @@ let symbol_name srk sym =
   else None
 
 let typ_symbol srk = snd % DynArray.get srk.symbols
+
 let pp_symbol srk formatter symbol =
   Format.fprintf formatter "%s:%d"
     (fst (DynArray.get srk.symbols symbol))
@@ -265,6 +301,9 @@ let mk_one srk = mk_real srk QQ.one
 let mk_const srk k = srk.mk (App k) []
 let mk_app srk symbol actuals = srk.mk (App symbol) actuals
 let mk_var srk v typ = srk.mk (Var (v, typ)) []
+
+let mk_select srk a i = srk.mk Select [a; i]
+let mk_store srk a i v = srk.mk Store [a; i; v]
 
 let mk_neg srk t = srk.mk Neg [t]
 let mk_div srk s t = srk.mk Div [s; t]
@@ -299,6 +338,7 @@ let mk_false srk = srk.mk False []
 let mk_leq srk s t = srk.mk Leq [s; t]
 let mk_lt srk s t = srk.mk Lt [s; t]
 let mk_eq srk s t = srk.mk Eq [s; t]
+let mk_arr_eq srk s t = srk.mk ArrEq [s; t]
 
 let is_true phi = match phi.obj with
   | Node (True, [], _) -> true
@@ -481,6 +521,8 @@ let destruct _srk sexpr =
   | Node (Floor, [t], _) -> `Unop (`Floor, t)
   | Node (Neg, [t], _) -> `Unop (`Neg, t)
   | Node (Ite, [cond; bthen; belse], _) -> `Ite (cond, bthen, belse)
+  | Node (Store, [a; i; v], `TyArr) -> `Store (a, i, v)
+  | Node (Select, [a; i], _) -> `Select (a, i)
   | Node (True, [], _) -> `Tru
   | Node (False, [], _) -> `Fls
   | Node (And, conjuncts, _) -> `And conjuncts
@@ -488,9 +530,10 @@ let destruct _srk sexpr =
   | Node (Not, [phi], _) -> `Not phi
   | Node (Exists (name, typ), [phi], _) -> `Quantify (`Exists, name, typ, phi)
   | Node (Forall (name, typ), [phi], _) -> `Quantify (`Forall, name, typ, phi)
-  | Node (Eq, [s; t], _) -> `Atom (`Eq, s, t)
-  | Node (Leq, [s; t], _) -> `Atom (`Leq, s, t)
-  | Node (Lt, [s; t], _) -> `Atom (`Lt, s, t)
+  | Node (Eq, [s; t], _) -> `Atom (`Arith (`Eq, s, t))
+  | Node (Leq, [s; t], _) -> `Atom (`Arith (`Leq, s, t))
+  | Node (Lt, [s; t], _) -> `Atom (`Arith (`Lt, s, t))
+  | Node (ArrEq, [s; t], _) -> `Atom (`ArrEq (s, t))
   | Node (_, _, _) -> assert false
 
 let rec flatten_universal phi = match phi.obj with
@@ -570,7 +613,8 @@ let rec pp_expr ?(env=Env.empty) srk formatter expr =
       formatter
       (BatList.enum (List.concat (List.map (flatten_sexpr Or) disjuncts)));
     fprintf formatter "@])"
-  | Eq, [x; y] ->
+  | Eq, [x; y]
+  | ArrEq, [x; y] ->
     fprintf formatter "@[%a = %a@]"
       (pp_expr ~env srk) x
       (pp_expr ~env srk) y
@@ -582,6 +626,15 @@ let rec pp_expr ?(env=Env.empty) srk formatter expr =
     fprintf formatter "@[%a < %a@]"
       (pp_expr ~env srk) x
       (pp_expr ~env srk) y
+  | Store, [a; i; v] ->
+    fprintf formatter "@(store %a %a %a)@]"
+      (pp_expr ~env srk) a
+      (pp_expr ~env srk) i
+      (pp_expr ~env srk) v
+  | Select, [a; i] ->
+    fprintf formatter "@[%a[%a]@]"
+      (pp_expr ~env srk) a
+      (pp_expr ~env srk) i
   | Exists (name, typ), [psi] | Forall (name, typ), [psi] ->
       let (quantifier_name, varinfo, psi) =
         match label with
@@ -707,7 +760,8 @@ let pp_expr_unnumbered ?(env=Env.empty) srk formatter expr =
         formatter
         (BatList.enum (List.concat (List.map (flatten_sexpr Or) disjuncts)));
       fprintf formatter "@])"
-    | Eq, [x; y] ->
+    | Eq, [x; y] 
+    | ArrEq, [x; y] ->
       fprintf formatter "@[%a = %a@]"
         (go ~env srk) x
         (go ~env srk) y
@@ -719,6 +773,15 @@ let pp_expr_unnumbered ?(env=Env.empty) srk formatter expr =
       fprintf formatter "@[%a < %a@]"
         (go ~env srk) x
         (go ~env srk) y
+    | Store, [a; i; v] ->
+      fprintf formatter "@(store %a %a %a)@]"
+        (pp_expr ~env srk) a
+        (pp_expr ~env srk) i
+        (pp_expr ~env srk) v
+    | Select, [a; i] ->
+      fprintf formatter "@[%a[%a@]"
+        (pp_expr ~env srk) a
+        (pp_expr ~env srk) i
     | Exists (name, typ), [psi] | Forall (name, typ), [psi] ->
         let (quantifier_name, varinfo, psi) =
           match label with
@@ -763,20 +826,44 @@ module Expr = struct
 
   let refine _srk sexpr =
     match sexpr.obj with
-    | Node (_, _, `TyInt) -> `Term sexpr
-    | Node (_, _, `TyReal) -> `Term sexpr
+    | Node (_, _, `TyInt)
+    | Node (_, _, `TyReal) -> `ArithTerm sexpr
+    | Node (_, _, `TyArr) -> `ArrTerm sexpr
+    | Node (_, _, `TyBool) -> `Formula sexpr
+
+  let refine_coarse _srk sexpr =
+    match sexpr.obj with
+    | Node (_, _, `TyInt)
+    | Node (_, _, `TyReal)
+    | Node (_, _, `TyArr) -> `Term sexpr
     | Node (_, _, `TyBool) -> `Formula sexpr
 
   let term_of _srk sexpr =
     match sexpr.obj with
     | Node (_, _, `TyInt)
-    | Node (_, _, `TyReal) -> sexpr
+    | Node (_, _, `TyReal)
+    | Node (_, _, `TyArr) -> sexpr
     | Node (_, _, `TyBool) -> invalid_arg "Syntax.term_of: not a term"
+
+let arith_term_of _srk sexpr =
+    match sexpr.obj with
+    | Node (_, _, `TyInt)
+    | Node (_, _, `TyReal) -> sexpr
+    | Node (_, _, `TyArr)
+    | Node (_, _, `TyBool) -> invalid_arg "Syntax.term_of: not an arithmetic term"
+
+let arr_term_of _srk sexpr =
+    match sexpr.obj with
+    | Node (_, _, `TyArr) -> sexpr
+    | Node (_, _, `TyInt)
+    | Node (_, _, `TyReal)
+    | Node (_, _, `TyBool) -> invalid_arg "Syntax.term_of: not an array term"
 
   let formula_of _srk sexpr =
     match sexpr.obj with
     | Node (_, _, `TyInt)
-    | Node (_, _, `TyReal) -> invalid_arg "Syntax.formula_of: not a formula"
+    | Node (_, _, `TyReal) 
+    | Node (_, _, `TyArr) -> invalid_arg "Syntax.formula_of: not a formula"
     | Node (_, _, `TyBool) -> sexpr
 
   let pp = pp_expr
@@ -847,12 +934,15 @@ module Term = struct
       match t.obj with
       | Node (Real qq, [], _) -> alg (`Real qq)
       | Node (App _, _, `TyBool) -> invalid_arg "eval: not a term"
-      | Node (App func, args, `TyInt) | Node (App func, args, `TyReal) ->
+      | Node (App func, args, `TyInt) 
+      | Node (App func, args, `TyReal)
+      | Node (App func, args, `TyArr) ->
         alg (`App (func, args))
       | Node (Var (v, typ), [], _) ->
         begin match typ with
           | `TyInt -> alg (`Var (v, `TyInt))
           | `TyReal -> alg (`Var (v, `TyReal))
+          | `TyArr -> alg (`Var (v, `TyArr))
           | `TyBool -> invalid_arg "eval: not a term"
         end
       | Node (Add, sum, _) -> alg (`Add (List.map go sum))
@@ -861,6 +951,131 @@ module Term = struct
       | Node (Mod, [s; t], _) -> alg (`Binop (`Mod, go s, go t))
       | Node (Floor, [t], _) -> alg (`Unop (`Floor, go t))
       | Node (Neg, [t], _) -> alg (`Unop (`Neg, go t))
+      | Node (Select, [a; i], `TyInt) -> alg(`Select (go a, go i))
+      | Node (Store, [a; i; v], `TyArr) -> alg(`Store(go a, go i, go v))
+      | Node (Ite, [cond; bthen; belse], `TyReal)
+      | Node (Ite, [cond; bthen; belse], `TyInt) 
+      | Node (Ite, [cond; bthen; belse], `TyArr) ->
+        alg (`Ite (cond, go bthen, go belse))
+      | _ -> invalid_arg "eval: not a term"
+    in
+    go t
+
+  let eval_partial srk alg t =
+    let alg' term =
+      match alg term with
+      | Some t -> t
+      | None -> raise Quit
+    in
+    try Some (eval srk alg' t)
+    with Quit -> None
+
+  let destruct _srk t = match t.obj with
+    | Node (Real qq, [], _) -> `Real qq
+    | Node (App _, _, `TyBool) -> invalid_arg "destruct: not a term"
+    | Node (App func, args, `TyInt) 
+    | Node (App func, args, `TyReal) 
+    | Node (App func, args, `TyArr) ->
+      `App (func, args)
+    | Node (Var (v, typ), [], _) ->
+      begin match typ with
+        | `TyInt -> `Var (v, `TyInt)
+        | `TyReal -> `Var (v, `TyReal)
+        | `TyArr -> `Var (v, `TyArr)
+        | `TyBool -> invalid_arg "destruct: not a term"
+      end
+    | Node (Add, sum, _) -> `Add sum
+    | Node (Mul, product, _) -> `Mul product
+    | Node (Div, [s; t], _) -> `Binop (`Div, s, t)
+    | Node (Mod, [s; t], _) -> `Binop (`Mod, s, t)
+    | Node (Floor, [t], _) -> `Unop (`Floor, t)
+    | Node (Neg, [t], _) -> `Unop (`Neg, t)
+    | Node (Select, [a; i], _) -> `Select (a, i)
+    | Node (Store, [a; i; v], `TyArr) -> `Store(a, i, v)
+    | Node (Ite, [cond; bthen; belse], `TyReal)
+    | Node (Ite, [cond; bthen; belse], `TyInt) 
+    | Node (Ite, [cond; bthen; belse], `TyArr) ->
+      `Ite (cond, bthen, belse)
+    | _ -> invalid_arg "destruct: not a term"
+
+  let construct _srk open_term = match open_term with
+    | `Real qq -> mk_real _srk qq
+    | `App(func, args) -> mk_app _srk func args
+    | `Var(v, `TyInt) -> mk_var _srk v `TyInt
+    | `Var(v, `TyReal) -> mk_var _srk v `TyReal
+    | `Var(v, `TyArr) -> mk_var _srk v `TyArr
+    | `Add sum -> mk_add _srk sum
+    | `Mul product -> mk_mul _srk product
+    | `Binop (`Div, s, t) -> mk_div _srk s t
+    | `Binop (`Mod, s, t) -> mk_mod _srk s t
+    | `Unop (`Floor, t) -> mk_floor _srk t
+    | `Unop (`Neg, t) -> mk_neg _srk t
+    | `Select (a, i) -> mk_select _srk a i
+    | `Store (a, i, v) -> mk_store _srk a i v
+    | `Ite (cond, bthen, belse) -> mk_ite _srk cond bthen belse
+
+  let pp = pp_expr
+  let show ?(env=Env.empty) srk t = SrkUtil.mk_show (pp ~env srk) t
+
+  let typ _ node =
+    match node.obj with
+    | Node (_, _, `TyInt) -> `TyInt
+    | Node (_, _, `TyReal) -> `TyReal
+    | Node (_, _, `TyArr) -> `TyArr
+    | Node (_, _, `TyBool) -> invalid_arg "term_typ: not a term"
+
+let refine _srk sexpr =
+    match sexpr.obj with
+    | Node (_, _, `TyInt)
+    | Node (_, _, `TyReal) -> `ArithTerm sexpr
+    | Node (_, _, `TyArr) -> `ArrTerm sexpr
+    | Node (_, _, `TyBool) -> assert false
+end
+
+
+module ArithTerm = struct
+  type 'a t = 'a arith_term
+
+  let arith_term_of _srk term =
+    match term.obj with
+    | Node (_, _, `TyInt)
+    | Node (_, _, `TyReal) -> term
+    | Node (_, _, `TyArr)
+    | Node (_, _, `TyBool) -> invalid_arg "Syntax.term_of: not an arithmetic term"
+
+  let typ _ node =
+    match node.obj with
+    | Node (_, _, `TyInt) -> `TyInt
+    | Node (_, _, `TyReal) -> `TyReal
+    | Node (_, _, `TyArr)
+    | Node (_, _, `TyBool) -> invalid_arg "term_typ: not an arithmetic term"
+
+  let equal s t = s.tag = t.tag
+  let compare s t = Stdlib.compare s.tag t.tag
+  let hash t = t.hcode
+
+  let eval _srk alg t =
+    let rec go t =
+      match t.obj with
+      | Node (Real qq, [], _) -> alg (`Real qq)
+      | Node (App _, _, `TyBool) | Node (App _, _, `TyArr) -> 
+        invalid_arg "eval: not arithmetic a term"
+      | Node (App func, args, `TyInt) | Node (App func, args, `TyReal) ->
+        alg (`App (func, args))
+      | Node (Var (v, typ), [], _) ->
+        begin match typ with
+          | `TyInt -> alg (`Var (v, `TyInt))
+          | `TyReal -> alg (`Var (v, `TyReal))
+          | `TyArr
+          | `TyBool -> invalid_arg "eval: not an arithmetic term"
+        end
+      | Node (Add, sum, _) -> alg (`Add (List.map go sum))
+      | Node (Mul, product, _) -> alg (`Mul (List.map go product))
+      | Node (Div, [s; t], _) -> alg (`Binop (`Div, go s, go t))
+      | Node (Mod, [s; t], _) -> alg (`Binop (`Mod, go s, go t))
+      | Node (Floor, [t], _) -> alg (`Unop (`Floor, go t))
+      | Node (Neg, [t], _) -> alg (`Unop (`Neg, go t))
+      | Node (Select, [a; i], `TyInt) -> alg(`Select (a, go i))
       | Node (Ite, [cond; bthen; belse], `TyReal)
       | Node (Ite, [cond; bthen; belse], `TyInt) ->
         alg (`Ite (cond, go bthen, go belse))
@@ -879,14 +1094,16 @@ module Term = struct
 
   let destruct _srk t = match t.obj with
     | Node (Real qq, [], _) -> `Real qq
-    | Node (App _, _, `TyBool) -> invalid_arg "destruct: not a term"
-    | Node (App func, args, `TyInt) | Node (App func, args, `TyReal) ->
+    | Node (App _, _, `TyBool) | Node (App _, _, `TyArr) ->
+      invalid_arg "destruct: not an arithmetic term"
+    | Node (App func, args, `TyInt) | Node (App func, args, `TyReal) -> 
       `App (func, args)
     | Node (Var (v, typ), [], _) ->
       begin match typ with
         | `TyInt -> `Var (v, `TyInt)
         | `TyReal -> `Var (v, `TyReal)
-        | `TyBool -> invalid_arg "destruct: not a term"
+        | `TyArr 
+        | `TyBool -> invalid_arg "destruct: not an arithmetic term"
       end
     | Node (Add, sum, _) -> `Add sum
     | Node (Mul, product, _) -> `Mul product
@@ -894,14 +1111,75 @@ module Term = struct
     | Node (Mod, [s; t], _) -> `Binop (`Mod, s, t)
     | Node (Floor, [t], _) -> `Unop (`Floor, t)
     | Node (Neg, [t], _) -> `Unop (`Neg, t)
+    | Node (Select, [a; i], _) -> `Select(a, i)
     | Node (Ite, [cond; bthen; belse], `TyReal)
     | Node (Ite, [cond; bthen; belse], `TyInt) ->
       `Ite (cond, bthen, belse)
     | _ -> invalid_arg "destruct: not a term"
 
+  let construct _srk open_term = match open_term with
+    | `Real qq -> mk_real _srk qq
+    | `App(func, args) -> mk_app _srk func args
+    | `Var(v, `TyInt) -> mk_var _srk v `TyInt
+    | `Var(v, `TyReal) -> mk_var _srk v `TyReal
+    | `Add sum -> mk_add _srk sum
+    | `Mul product -> mk_mul _srk product
+    | `Binop (`Div, s, t) -> mk_div _srk s t
+    | `Binop (`Mod, s, t) -> mk_mod _srk s t
+    | `Select (a, i) -> mk_select _srk a i
+    | `Unop (`Floor, t) -> mk_floor _srk t
+    | `Unop (`Neg, t) -> mk_neg _srk t
+    | `Ite (cond, bthen, belse) -> mk_ite _srk cond bthen belse
+
   let pp = pp_expr
   let show ?(env=Env.empty) srk t = SrkUtil.mk_show (pp ~env srk) t
 end
+
+
+module ArrTerm = struct
+  type 'a t = 'a arr_term
+  let equal s t = s.tag = t.tag
+  let compare s t = Stdlib.compare s.tag t.tag
+  let hash t = t.hcode
+
+  let eval _srk alg t =
+    let rec go t =
+      match t.obj with
+      | Node (App func, args, `TyArr) -> alg (`App (func, args))
+      | Node (Var (v, `TyArr), [], _) -> alg (`Var (v, `TyArr))
+      | Node (Store, [a; i; v], _) -> alg(`Store (go a, i, v))
+      | Node (Ite, [cond; bthen; belse], `TyArr) -> 
+        alg (`Ite (cond, go bthen, go belse))
+      | _ -> invalid_arg "eval: not an array term"
+    in
+    go t
+
+  let eval_partial srk alg t =
+    let alg' term =
+      match alg term with
+      | Some t -> t
+      | None -> raise Quit
+    in
+    try Some (eval srk alg' t)
+    with Quit -> None
+
+  let destruct _srk t = match t.obj with
+    | Node (App func, args, `TyArr)-> `App (func, args)
+    | Node (Var (v, `TyArr), [], _) -> `Var (v, `TyArr)
+    | Node (Ite, [cond; bthen; belse], `TyArr) -> `Ite (cond, bthen, belse)
+    | Node (Store, [a; i; v], _) -> `Store (a, i ,v)
+    | _ -> invalid_arg "destruct: not a term"
+
+  let construct _srk open_term = match open_term with
+    | `App(func, args) -> mk_app _srk func args
+    | `Var(v, `TyArr) -> mk_var _srk v `TyArr
+    | `Ite (cond, bthen, belse) -> mk_ite _srk cond bthen belse
+    | `Store (a, i, v) -> mk_store _srk a i v
+
+  let pp = pp_expr
+  let show ?(env=Env.empty) srk t = SrkUtil.mk_show (pp ~env srk) t
+end
+
 
 module Formula = struct
   type 'a t = 'a formula
@@ -919,13 +1197,30 @@ module Formula = struct
       `Quantify (`Exists, name, typ, phi)
     | Node (Forall (name, typ), [phi], _) ->
       `Quantify (`Forall, name, typ, phi)
-    | Node (Eq, [s; t], _) -> `Atom (`Eq, s, t)
-    | Node (Leq, [s; t], _) -> `Atom (`Leq, s, t)
-    | Node (Lt, [s; t], _) -> `Atom (`Lt, s, t)
+    | Node (Eq, [s; t], _) -> `Atom (`Arith (`Eq, s, t))
+    | Node (Leq, [s; t], _) -> `Atom (`Arith (`Leq, s, t))
+    | Node (Lt, [s; t], _) -> `Atom (`Arith (`Lt, s, t))
+    | Node (ArrEq, [s; t], _) -> `Atom (`ArrEq (s, t))
     | Node (Var (v, `TyBool), [], _) -> `Proposition (`Var v)
     | Node (App f, args, `TyBool) -> `Proposition (`App (f, args))
     | Node (Ite, [cond; bthen; belse], `TyBool) -> `Ite (cond, bthen, belse)
     | _ -> invalid_arg "destruct: not a formula"
+
+  let construct _srk open_formula = match open_formula with
+    | `Tru -> mk_true _srk
+    | `Fls -> mk_false _srk
+    | `And conjuncts -> mk_and _srk conjuncts
+    | `Or disjuncts -> mk_or _srk disjuncts
+    | `Not phi -> mk_not _srk phi
+    | `Quantify (`Exists, name, typ, phi) -> mk_exists _srk ~name typ phi
+    | `Quantify (`Forall, name, typ, phi) -> mk_forall _srk ~name typ phi
+    | `Atom (`Arith (`Eq, s, t)) -> mk_eq _srk s t
+    | `Atom (`Arith (`Leq, s, t)) -> mk_leq _srk s t
+    | `Atom (`Arith (`Lt, s, t)) -> mk_lt _srk s t
+    | `Atom (`ArrEq (s, t)) -> mk_arr_eq _srk s t
+    | `Proposition (`Var v) -> mk_const _srk v
+    | `Proposition (`App (f, args)) -> mk_app _srk f args
+    | `Ite (cond, bthen, belse) -> mk_ite _srk cond bthen belse
 
   let rec eval srk alg phi = match destruct srk phi with
     | `Tru -> alg `Tru
@@ -935,7 +1230,7 @@ module Formula = struct
     | `Quantify (qt, name, typ, phi) ->
       alg (`Quantify (qt, name, typ, eval srk alg phi))
     | `Not phi -> alg (`Not (eval srk alg phi))
-    | `Atom (op, s, t) -> alg (`Atom (op, s, t))
+    | `Atom c -> alg (`Atom c)
     | `Proposition p -> alg (`Proposition p)
     | `Ite (cond, bthen, belse) ->
       alg (`Ite (eval srk alg cond, eval srk alg bthen, eval srk alg belse))
@@ -953,7 +1248,7 @@ module Formula = struct
           | `Quantify (qt, name, typ, phi) ->
             alg (`Quantify (qt, name, typ, go phi))
           | `Not phi -> alg (`Not (go phi))
-          | `Atom (op, s, t) -> alg (`Atom (op, s, t))
+          | `Atom c -> alg (`Atom c)
           | `Proposition p -> alg (`Proposition p)
           | `Ite (cond, bthen, belse) ->
             alg (`Ite (go cond, go bthen, go belse))
@@ -1020,9 +1315,7 @@ module Formula = struct
     let alg = function
       | `Tru -> ([], mk_true srk)
       | `Fls -> ([], mk_false srk)
-      | `Atom (`Eq, x, y) -> ([], mk_eq srk x y)
-      | `Atom (`Lt, x, y) -> ([], mk_lt srk x y)
-      | `Atom (`Leq, x, y) -> ([], mk_leq srk x y)
+      | `Atom c -> ([], construct srk (`Atom c))
       | `And conjuncts ->
         let (qf_pre, conjuncts) = combine conjuncts in
         (qf_pre, mk_and srk conjuncts)
@@ -1139,10 +1432,27 @@ let node_typ symbols label children =
       | `TyInt when children = [] -> `TyInt
       | `TyReal when children = [] -> `TyReal
       | `TyBool when children = [] -> `TyBool
+      | `TyArr when children = [] -> `TyArr
       | _ -> invalid_arg "Application of a non-function symbol"
     end
+  | Store ->
+    begin match children with
+      | [a; i; v] -> begin match a.obj, i.obj, v.obj with
+          | Node (_, _, `TyArr), Node(_, _, `TyInt), Node (_, _, `TyInt)  -> `TyArr
+          | _ -> invalid_arg "invalid array store"
+        end
+      |  _ -> assert false
+    end
+  | Select -> 
+    begin match children with
+      | [a; i] -> begin match a.obj, i.obj with
+          | Node (_, _, `TyArr), Node(_, _, `TyInt) -> `TyInt
+          | _ -> invalid_arg "invalid array select"
+        end
+      |  _ -> assert false
+    end
   | Forall (_, _) | Exists (_, _) | And | Or | Not
-  | True | False | Eq | Leq | Lt  -> `TyBool
+  | True | False | Eq | Leq | Lt | ArrEq -> `TyBool
   | Floor -> `TyInt
   | Div -> `TyReal
   | Add | Mul | Mod | Neg ->
@@ -1165,21 +1475,18 @@ let node_typ symbols label children =
           | Node (_, _, `TyBool), Node (_, _, `TyReal), Node (_, _, `TyInt)
           | Node (_, _, `TyBool), Node (_, _, `TyReal), Node (_, _, `TyReal) ->
             `TyReal
+          | Node (_, _, `TyBool), Node (_, _, `TyArr), Node (_, _, `TyArr) ->
+            `TyArr
           | _, _, _ -> invalid_arg "ill-typed if-then-else"
         end
       | _ -> assert false
     end
 
-let term_typ _ node =
-  match node.obj with
-  | Node (_, _, `TyInt) -> `TyInt
-  | Node (_, _, `TyReal) -> `TyReal
-  | Node (_, _, `TyBool) -> invalid_arg "term_typ: not an arithmetic term"
-
 let expr_typ _ node =
   match node.obj with
   | Node (_, _, `TyInt) -> `TyInt
   | Node (_, _, `TyReal) -> `TyReal
+  | Node (_, _, `TyArr) -> `TyArr
   | Node (_, _, `TyBool) -> `TyBool
 
 type 'a rewriter = ('a, typ_fo) expr -> ('a, typ_fo) expr
@@ -1194,6 +1501,14 @@ let rec nnf_rewriter srk sexpr =
       | Node (Leq, [s; t], _) -> mk_lt srk t s
       | Node (Eq, [s; t], _) -> mk_or srk [mk_lt srk s t; mk_lt srk t s]
       | Node (Lt, [s; t], _) -> mk_leq srk t s
+      | Node (ArrEq, [s; t], _) ->
+        let s_i = mk_select srk (decapture srk 0 1 s) (mk_var srk 0 `TyInt) in
+        let t_i = mk_select srk (decapture srk 0 1 t) (mk_var srk 0 `TyInt) in
+        mk_exists 
+          srk 
+          ~name:"i" 
+          `TyInt 
+          (mk_or srk [mk_lt srk s_i t_i; mk_lt srk t_i s_i])
       | Node (Exists (name, typ), [psi], _) ->
         mk_forall srk ~name typ (mk_not srk psi)
       | Node (Forall (name, typ), [psi], _) ->
@@ -1252,9 +1567,23 @@ let eliminate_ite srk phi =
       map_ite (fun t -> `Term (mk_neg srk t)) (promote_ite x)
     | `Unop (`Floor, x) ->
       map_ite (fun t -> `Term (mk_floor srk t)) (promote_ite x)
+    | `Store (a, v, i) -> 
+      let promote_i = promote_ite i in
+      let promote_v = promote_ite v in
+      map_ite
+        (fun t -> 
+           map_ite 
+             (fun s -> map_ite (fun u -> `Term (mk_store srk t s u)) promote_i)
+             promote_v)
+        (promote_ite a)
+    | `Select (x, y) ->
+      let promote_y = promote_ite y in
+      map_ite
+        (fun t -> map_ite (fun s -> `Term (mk_select srk t s)) promote_y)
+        (promote_ite x)
     | `App (func, args) ->
       List.fold_right (fun x rest ->
-          match Expr.refine srk x with
+          match Expr.refine_coarse srk x with
           | `Formula phi ->
             let phi = elim_ite phi in
             map_ite (fun xs -> `Term (phi::xs)) rest
@@ -1282,16 +1611,22 @@ let eliminate_ite srk phi =
       | `Quantify (`Exists, name, typ, phi) -> mk_exists srk ~name typ phi
       | `Quantify (`Forall, name, typ, phi) -> mk_forall srk ~name typ phi
       | `Ite (cond, bthen, belse) -> mk_ite cond bthen belse
-      | `Atom (op, s, t) ->
+      | `Atom (`Arith (op, s, t)) -> 
         let promote_t = promote_ite t in
         map_ite
           (fun s -> map_ite (fun t -> `Term (mk_atom op s t)) promote_t)
           (promote_ite s)
         |> ite_formula
+      | `Atom (`ArrEq (s, t)) ->
+        let promote_t = promote_ite t in
+        map_ite
+          (fun s -> map_ite (fun t -> `Term (mk_arr_eq srk s t)) promote_t)
+          (promote_ite s)
+        |> ite_formula
       | `Proposition (`Var i) -> mk_var srk i `TyBool
       | `Proposition (`App (func, args)) ->
         List.fold_right (fun x rest ->
-            match Expr.refine srk x with
+            match Expr.refine_coarse srk x with
             | `Formula phi ->
               let phi = elim_ite phi in
               map_ite (fun xs -> `Term (phi::xs)) rest
@@ -1307,6 +1642,54 @@ let eliminate_ite srk phi =
     Formula.eval srk alg phi
   in
   elim_ite phi
+
+let eliminate_arr_eq srk phi =
+  let alg = function
+    | `Atom (`ArrEq (s, t)) ->
+      let s_i = mk_select srk (decapture srk 0 1 s) (mk_var srk 0 `TyInt) in 
+      let t_i = mk_select srk (decapture srk 0 1 t) (mk_var srk 0 `TyInt) in
+      mk_forall srk ~name:"i" `TyInt (mk_eq srk s_i t_i)
+    | phi -> Formula.construct srk phi
+  in
+  Formula.eval srk alg phi
+
+let eliminate_stores srk phi =
+  let mk_op op =
+    match op with
+    | `Eq -> mk_eq
+    | `Lt -> mk_lt
+    | `Leq -> mk_leq
+  in
+  let rec rewrite_store index node =
+    match ArrTerm.destruct srk node with
+    | `Store (a, i, v) ->
+      let i = ArithTerm.eval srk arith_alg i in
+      let v = ArithTerm.eval srk arith_alg v in
+      mk_ite srk (mk_eq srk i index) v (rewrite_store index a)
+    | `Var (ind, `TyArr) -> mk_select srk (mk_var srk ind `TyArr) index
+    | `App (a, []) -> mk_select srk (mk_const srk a) index
+    | `Ite (phi, a, b) -> 
+      mk_ite 
+        srk 
+        (Formula.eval srk alg phi) 
+        (rewrite_store index a)
+        (rewrite_store index b)
+    | _ -> assert false (*todo: func app*)
+  and  arith_alg = function
+    | `Select (a, i) -> rewrite_store i a
+    | `Ite (phi, x, y) -> mk_ite srk (Formula.eval srk alg phi) x y
+    | open_term -> Term.construct srk open_term
+  and alg = function
+    | `Atom (`Arith (op, x, y)) ->
+      (mk_op op) srk (ArithTerm.eval srk arith_alg x) (ArithTerm.eval srk arith_alg y)
+    | `Atom(`ArrEq (a, b)) -> 
+      let index = mk_symbol srk `TyInt in
+      let lhs = rewrite_store (mk_const srk index) a in
+      let rhs = rewrite_store (mk_const srk index) b in
+      mk_forall_const srk index (mk_eq srk lhs rhs)
+    | open_formula -> Formula.construct srk open_formula
+  in
+  Formula.eval srk alg phi
 
 let pp_smtlib2_gen ?(named=false) ?(env=Env.empty) ?(strings=Hashtbl.create 991) srk formatter assertions =
   let open Format in
@@ -1375,6 +1758,7 @@ let pp_smtlib2_gen ?(named=false) ?(env=Env.empty) ?(strings=Hashtbl.create 991)
     | `TyReal -> pp_print_string formatter "Real"
     | `TyInt -> pp_print_string formatter "Int"
     | `TyBool -> pp_print_string formatter "Bool"
+    | `TyArr -> pp_print_string formatter "(Array (Int) Int)"
   in
   (* print declarations *)
   symbol_name |> Hashtbl.iter (fun symbol name ->
@@ -1382,6 +1766,7 @@ let pp_smtlib2_gen ?(named=false) ?(env=Env.empty) ?(strings=Hashtbl.create 991)
       | `TyReal -> fprintf formatter "(declare-const %s Real)@;" name
       | `TyInt -> fprintf formatter "(declare-const %s Int)@;" name
       | `TyBool -> fprintf formatter "(declare-const %s Bool)@;" name
+      | `TyArr -> fprintf formatter "(declare-const %s (Array (Int) Int))@;" name
       | `TyFun (args, ret) ->
         fprintf formatter "(declare-fun %s (%a) %a)@;"
           name
@@ -1389,7 +1774,7 @@ let pp_smtlib2_gen ?(named=false) ?(env=Env.empty) ?(strings=Hashtbl.create 991)
           pp_typ_fo ret
     );
 
-  let rec go env formatter expr =
+    let rec go env formatter expr =
     let Node (label, children, _) = expr.obj in
     match label, children with
     | Real qq, [] ->
@@ -1459,7 +1844,9 @@ let pp_smtlib2_gen ?(named=false) ?(env=Env.empty) ?(strings=Hashtbl.create 991)
         formatter
         (BatList.enum (List.concat (List.map (flatten_sexpr Or) disjuncts)));
       fprintf formatter "@])"
-    | Eq, [x; y] ->
+    (* Potentially misleading since user may expect expansion of ArrEq
+     * syntactic sugar prior to conversion to smt2 *)
+    | Eq, [x; y] | ArrEq, [x; y] ->
       fprintf formatter "(= @[%a %a@])"
         (go env) x
         (go env) y
@@ -1538,29 +1925,36 @@ struct
   let forall = mk_forall C.context
   let exists = mk_exists C.context
   let var = mk_var C.context
+  let ( .%[] ) = mk_select C.context
+  let ( .%[]<- ) = mk_store C.context
+  let ( == ) = mk_arr_eq C.context
 end
 
 module type Context = sig
   type t (* magic type parameter unique to this context *)
   val context : t context
-  type term = (t, typ_arith) expr
+  type term = (t, typ_term) expr
+  type arith_term = (t, typ_arith) expr
+  type arr_term = (t, typ_arr) expr
   type formula = (t, typ_bool) expr
 
   val mk_symbol : ?name:string -> typ -> symbol
   val mk_const : symbol -> ('a, 'typ) expr
   val mk_app : symbol -> ('a, 'b) expr list -> ('a, 'typ) expr
   val mk_var : int -> typ_fo -> ('a, 'typ) expr
-  val mk_add : term list -> term
-  val mk_mul : term list -> term
-  val mk_div : term -> term -> term
-  val mk_idiv : term -> term -> term
-  val mk_mod : term -> term -> term
-  val mk_real : QQ.t -> term
-  val mk_zz : ZZ.t -> term
-  val mk_int : int -> term
-  val mk_floor : term -> term
-  val mk_neg : term -> term
-  val mk_sub : term -> term -> term
+  val mk_add : arith_term list -> arith_term
+  val mk_mul : arith_term list -> arith_term
+  val mk_div : arith_term -> arith_term -> arith_term
+  val mk_idiv : arith_term -> arith_term -> arith_term
+  val mk_mod : arith_term -> arith_term -> arith_term
+  val mk_real : QQ.t -> arith_term
+  val mk_zz : ZZ.t -> arith_term
+  val mk_int : int -> arith_term
+  val mk_floor : arith_term -> arith_term
+  val mk_neg : arith_term -> arith_term
+  val mk_sub : arith_term -> arith_term -> arith_term
+  val mk_select : arr_term -> arith_term -> arith_term
+  val mk_store : arr_term -> arith_term -> arith_term -> arr_term
   val mk_forall : ?name:string -> typ_fo -> formula -> formula
   val mk_exists : ?name:string -> typ_fo -> formula -> formula
   val mk_forall_const : symbol -> formula -> formula
@@ -1568,9 +1962,10 @@ module type Context = sig
   val mk_and : formula list -> formula
   val mk_or : formula list -> formula
   val mk_not : formula -> formula
-  val mk_eq : term -> term -> formula
-  val mk_lt : term -> term -> formula
-  val mk_leq : term -> term -> formula
+  val mk_eq : arith_term -> arith_term -> formula
+  val mk_lt : arith_term -> arith_term -> formula
+  val mk_leq : arith_term -> arith_term -> formula
+  val mk_arr_eq : arr_term -> arr_term -> formula
   val mk_true : formula
   val mk_false : formula
   val mk_ite : formula -> (t, 'a) expr -> (t, 'a) expr -> (t, 'a) expr
@@ -1597,6 +1992,8 @@ module ImplicitContext(C : sig
   let mk_floor = mk_floor context
   let mk_neg = mk_neg context
   let mk_sub = mk_sub context
+  let mk_select = mk_select context
+  let mk_store = mk_store context
   let mk_forall = mk_forall context
   let mk_exists = mk_exists context
   let mk_forall_const = mk_forall_const context
@@ -1607,6 +2004,7 @@ module ImplicitContext(C : sig
   let mk_eq = mk_eq context
   let mk_lt = mk_lt context
   let mk_leq = mk_leq context
+  let mk_arr_eq = mk_arr_eq context
   let mk_true = mk_true context
   let mk_false = mk_false context
   let mk_ite = mk_ite context
@@ -1616,7 +2014,10 @@ end
 module MakeContext () =
 struct
   type t = unit
-  type term = (t, typ_arith) expr
+  type term = (t, typ_term) expr
+  type arith_term = (t, typ_arith) expr
+  type arr_term = (t, typ_arr) expr
+
   type formula = (t, typ_bool) expr
 
   let context =
@@ -1639,7 +2040,10 @@ end
 module MakeSimplifyingContext () =
 struct
   type t = unit
-  type term = (t, typ_arith) expr
+  type term = (t, typ_term) expr
+  type arith_term = (t, typ_arith) expr
+  type arr_term = (t, typ_arr) expr
+
   type formula = (t, typ_bool) expr
 
   let context =
@@ -1672,8 +2076,10 @@ struct
         begin match x.obj, y.obj with
           | Node (Real xv, [], _), Node (Real yv, [], _) ->
             if QQ.equal xv yv then true_ else false_
-          | _ -> hc label [x; y]
+          | _ -> if x = y then true_ else hc label [x; y]
         end
+      
+      | ArrEq, [x; y] -> if x = y then true_ else hc label [x; y]
 
       | And, conjuncts ->
         if List.exists is_false conjuncts then

--- a/srk/src/syntax.ml
+++ b/srk/src/syntax.ml
@@ -1218,7 +1218,7 @@ module Formula = struct
     | `Atom (`Arith (`Leq, s, t)) -> mk_leq _srk s t
     | `Atom (`Arith (`Lt, s, t)) -> mk_lt _srk s t
     | `Atom (`ArrEq (s, t)) -> mk_arr_eq _srk s t
-    | `Proposition (`Var v) -> mk_const _srk v
+    | `Proposition (`Var v) -> mk_var _srk v `TyBool
     | `Proposition (`App (f, args)) -> mk_app _srk f args
     | `Ite (cond, bthen, belse) -> mk_ite _srk cond bthen belse
 
@@ -1850,6 +1850,15 @@ let pp_smtlib2_gen ?(named=false) ?(env=Env.empty) ?(strings=Hashtbl.create 991)
         (go env) cond
         (go env) bthen
         (go env) belse
+    | Select, [a; i] ->
+      fprintf formatter "(select %a %a)"
+        (go env) a
+        (go env) i
+    | Store, [a; i; v] ->
+      fprintf formatter "(store %a %a %a)"
+        (go env) a
+        (go env) i
+        (go env) v
     | _ -> failwith "pp_smtlib2: ill-formed expression"
   in
   List.iteri (fun i phi ->

--- a/srk/src/syntax.mli
+++ b/srk/src/syntax.mli
@@ -437,6 +437,10 @@ val mk_false : 'a context -> 'a formula
 (** This is syntactic sugar for intrinsic array equality *)
 val mk_arr_eq : 'a context -> 'a arr_term -> 'a arr_term -> 'a formula
 
+(** Syntactic sugar for creating arithmetic relation atoms *)
+val mk_compare : [ `Eq | `Leq | `Lt ] -> 'a context -> 'a arith_term -> 
+  'a arith_term -> 'a formula
+
 (** Given a formula [phi], compute an equivalent formula without
    if-then-else terms.  [eliminate-ite] does not introduce new
    symbols or quantifiers. *)
@@ -445,10 +449,6 @@ val eliminate_ite : 'a context -> 'a formula -> 'a formula
 (** Given a formula [phi], compute an equivalent formula without
    arr_eq terms. *)
 val eliminate_arr_eq : 'a context -> 'a formula -> 'a formula
-
-(** Given a formula [phi], compute an equivalent formula without
-   array stores. Note that this implicitly eliminates arr_eqs too.*)
-val eliminate_stores : 'a context -> 'a formula -> 'a formula
 
 (** Print a formula as a satisfiability query in SMTLIB2 format.
     The query includes function declarations and (check-sat).

--- a/srk/src/terminationDTA.ml
+++ b/srk/src/terminationDTA.ml
@@ -470,7 +470,7 @@ module XSeq = struct
       | `Or xs -> seq_or srk xs
       | `Not x -> seq_not srk x
       | `Quantify _ -> failwith "should not see quantifiers in the TF"
-      | `Atom (op, s, t) -> 
+      | `Atom (`Arith (op, s, t)) -> 
         begin
           logf "simplifying atomic formula";
           match SrkSimplify.simplify_integer_atom srk op s t with 
@@ -478,6 +478,7 @@ module XSeq = struct
             | `Divides (divisor, vec) -> seq_of_divides_atom srk divisor vec exp_poly abstraction
             | `NotDivides (divisor, vec) ->seq_of_notdivides_atom srk divisor vec exp_poly abstraction
         end
+      | `Atom (`ArrEq _) -> failwith "should not see ArrEq in the TF"
       | `Proposition _ -> failwith "should not see proposition in the TF"
       | `Ite _ -> failwith "should not see ite in the TF"
     in

--- a/srk/src/transition.ml
+++ b/srk/src/transition.ml
@@ -22,10 +22,12 @@ module Make
 struct
   module M = BatMap.Make(Var)
 
+  module Term = ArithTerm
+
   type var = Var.t
 
   type t =
-    { transform : (C.t term) M.t;
+    { transform : (C.t arith_term) M.t;
       guard : C.t formula }
 
   let compare x y =
@@ -452,7 +454,7 @@ struct
             Symbol.Map.enum t_defs
             /@ (fun (v,t) ->
               match Expr.refine srk t with
-              | `Term t ->
+              | `ArithTerm t ->
                  mk_eq srk (mk_const srk v) (Nonlinear.interpret srk t)
               | _ -> assert false)
             |> BatList.of_enum

--- a/srk/src/transition.mli
+++ b/srk/src/transition.mli
@@ -46,7 +46,7 @@ module Make
   val show : t -> string
 
   (** Guarded parallel assignment *)
-  val construct : C.t formula -> (var * C.t term) list -> t
+  val construct : C.t formula -> (var * C.t arith_term) list -> t
 
   (** [assume phi] is a transition that doesn't modify any variables, but can
       only be executed when [phi] holds *)
@@ -54,12 +54,12 @@ module Make
 
   (** [assign v t] is a transition that assigns the term [t] to the variable
       [v]. *)
-  val assign : var -> C.t term -> t
+  val assign : var -> C.t arith_term -> t
 
   (** Parallel assignment of a list of terms to a list of variables.
      If a variable appears multiple times as a target for an
      assignment, the rightmost assignment is taken. *)
-  val parallel_assign : (var * C.t term) list -> t
+  val parallel_assign : (var * C.t arith_term) list -> t
 
   (** Assign a list of variables non-deterministic values. *)
   val havoc : var list -> t
@@ -96,10 +96,10 @@ module Make
 
   (** Retrieve the value of a variable after a transition as a term over input
       variables (and Skolem constants) *)
-  val get_transform : var -> t -> C.t term
+  val get_transform : var -> t -> C.t arith_term
 
   (** Enumerate the variables and values assigned in a transition. *)
-  val transform : t -> (var * C.t term) BatEnum.t
+  val transform : t -> (var * C.t arith_term) BatEnum.t
 
   (** The condition under which a transition may be executed. *)
   val guard : t -> C.t formula

--- a/srk/src/transitionSystem.ml
+++ b/srk/src/transitionSystem.ml
@@ -31,9 +31,9 @@ module Make
        type var = Var.t
        val pp : Format.formatter -> t -> unit
        val guard : t -> C.t formula
-       val transform : t -> (var * C.t term) BatEnum.t
+       val transform : t -> (var * C.t arith_term) BatEnum.t
        val mem_transform : var -> t -> bool
-       val get_transform : var -> t -> C.t term
+       val get_transform : var -> t -> C.t arith_term
        val assume : C.t formula -> t
        val mul : t -> t -> t
        val add : t -> t -> t

--- a/srk/src/transitionSystem.mli
+++ b/srk/src/transitionSystem.mli
@@ -25,9 +25,9 @@ module Make
        type var = Var.t
        val pp : Format.formatter -> t -> unit
        val guard : t -> C.t formula
-       val transform : t -> (var * C.t term) BatEnum.t
+       val transform : t -> (var * C.t arith_term) BatEnum.t
        val mem_transform : var -> t -> bool
-       val get_transform : var -> t -> C.t term
+       val get_transform : var -> t -> C.t arith_term
        val assume : C.t formula -> t
        val mul : t -> t -> t
        val add : t -> t -> t

--- a/srk/src/vas.ml
+++ b/srk/src/vas.ml
@@ -23,6 +23,7 @@ module Transformer = struct
 end
 
 module TSet = BatSet.Make(Transformer)
+module Term = ArithTerm
 
 type vas = TSet.t
 

--- a/srk/src/vas.mli
+++ b/srk/src/vas.mli
@@ -17,21 +17,21 @@ type 'a t = { v : vas; s_lst : M.t list}
 val gamma : 'a context ->  'a t -> (symbol * symbol) list -> 'a formula
 val abstract : 'a context -> 'a TransitionFormula.t -> 'a t
 val pp : 'a context -> (symbol * symbol) list -> Format.formatter -> 'a t -> unit
-val exp : 'a context -> (symbol * symbol) list -> 'a term -> 'a t -> 'a formula
+val exp : 'a context -> (symbol * symbol) list -> 'a arith_term -> 'a t -> 'a formula
 
 (* TODO: remove exp_base_helper *)
-val exp_base_helper : 'a context -> (symbol * Symbol.Map.key) list -> 'a term ->
+val exp_base_helper : 'a context -> (symbol * Symbol.Map.key) list -> 'a arith_term ->
   M.t list -> transformer list -> 
-  'a formula * (('a term list * ('a term * Z.dim) list * 'a term * 'a term)
-                  list * 'a term list list * 'a term list)
+  'a formula * (('a arith_term list * ('a arith_term * Z.dim) list * 'a arith_term * 'a arith_term)
+                  list * 'a arith_term list list * 'a arith_term list)
 
 (* TODO: remove exp_other_reset_helper *)
-val exp_other_reset_helper : 'a context -> 'a term -> 'a term list -> 'a term list list 
+val exp_other_reset_helper : 'a context -> 'a arith_term -> 'a arith_term list -> 'a arith_term list list 
   -> int -> 'a formula
 
 val term_list : 'a context -> M.t list -> (symbol * Symbol.Map.key) list -> 
-  (('a, typ_arith) expr * 'a term) list
-val gamma_transformer : 'a context -> ('a term * 'a term) list -> transformer -> 'a formula
+  (('a, typ_arith) expr * 'a arith_term) list
+val gamma_transformer : 'a context -> ('a arith_term * 'a arith_term) list -> transformer -> 'a formula
 val alpha_hat  : 'a context -> 'a formula -> (symbol * symbol) list ->  'c t
 val coprod_compute_image : TSet.t -> M.t list -> TSet.t
 val coprod_find_transformation : M.t list -> M.t list -> 

--- a/srk/src/vass.mli
+++ b/srk/src/vass.mli
@@ -5,5 +5,5 @@ open Syntax
 
 type 'a t
 val pp : 'a context -> (symbol * symbol) list -> Format.formatter -> 'a t -> unit
-val exp : 'a context -> (symbol * symbol) list -> 'a term -> 'a t -> 'a formula
+val exp : 'a context -> (symbol * symbol) list -> 'a arith_term -> 'a t -> 'a formula
 val abstract : 'a context -> 'a TransitionFormula.t -> 'a t

--- a/srk/src/wedge.ml
+++ b/srk/src/wedge.ml
@@ -217,33 +217,33 @@ let lincons_of_atom srk cs env atom =
   let vec_of_term = CS.vec_of_term cs in
   let linexpr_of_vec = linexpr_of_vec cs env in
   match Interpretation.destruct_atom srk atom with
-  | `Arith_Comparison (`Lt, x, y) ->
+  | `ArithComparison (`Lt, x, y) ->
     Lincons0.make
       (linexpr_of_vec
          (V.add (vec_of_term y) (V.negate (vec_of_term x))))
       Lincons0.SUP
-  | `Arith_Comparison (`Leq, x, y) ->
+  | `ArithComparison (`Leq, x, y) ->
     Lincons0.make
       (linexpr_of_vec
          (V.add (vec_of_term y) (V.negate (vec_of_term x))))
       Lincons0.SUPEQ
-  | `Arith_Comparison (`Eq, x, y) ->
+  | `ArithComparison (`Eq, x, y) ->
     Lincons0.make
       (linexpr_of_vec
          (V.add (vec_of_term y) (V.negate (vec_of_term x))))
       Lincons0.EQ
   | `Literal (_, _) 
-  | `Arr_Comparison _ -> assert false
+  | `ArrEq _ -> assert false
 
 let meet_atoms wedge atoms =
   (* Ensure that the coordinate system admits each atom *)
   atoms |> List.iter (fun atom ->
       match Interpretation.destruct_atom wedge.srk atom with
-      | `Arith_Comparison (_, x, y) ->
+      | `ArithComparison (_, x, y) ->
         CS.admit_term wedge.cs x;
         CS.admit_term wedge.cs y
       | `Literal (_, _) 
-      | `Arr_Comparison _ -> assert false);
+      | `ArrEq _ -> assert false);
   update_env wedge;
   let abstract =
     atoms
@@ -1306,11 +1306,11 @@ let of_atoms srk atoms =
   let cs = CS.mk_empty srk in
   let register_terms atom =
     match Interpretation.destruct_atom srk atom with
-    | `Arith_Comparison (_, x, y) ->
+    | `ArithComparison (_, x, y) ->
       CS.admit_term cs x;
       CS.admit_term cs y
     | `Literal (_, _) 
-    | `Arr_Comparison _ -> assert false
+    | `ArrEq _ -> assert false
   in
   List.iter register_terms atoms;
   let env = mk_env cs in
@@ -1348,11 +1348,11 @@ let common_cs wedge wedge' =
   let cs = CS.mk_empty srk in
   let register_terms atom =
     match Interpretation.destruct_atom srk atom with
-    | `Arith_Comparison (_, x, y) ->
+    | `ArithComparison (_, x, y) ->
       CS.admit_term cs x;
       CS.admit_term cs y
     | `Literal (_, _) 
-    | `Arr_Comparison _ -> assert false
+    | `ArrEq _ -> assert false
   in
   let atoms = to_atoms wedge in
   let atoms' = to_atoms wedge' in

--- a/srk/src/wedge.ml
+++ b/srk/src/wedge.ml
@@ -217,31 +217,33 @@ let lincons_of_atom srk cs env atom =
   let vec_of_term = CS.vec_of_term cs in
   let linexpr_of_vec = linexpr_of_vec cs env in
   match Interpretation.destruct_atom srk atom with
-  | `Comparison (`Lt, x, y) ->
+  | `Arith_Comparison (`Lt, x, y) ->
     Lincons0.make
       (linexpr_of_vec
          (V.add (vec_of_term y) (V.negate (vec_of_term x))))
       Lincons0.SUP
-  | `Comparison (`Leq, x, y) ->
+  | `Arith_Comparison (`Leq, x, y) ->
     Lincons0.make
       (linexpr_of_vec
          (V.add (vec_of_term y) (V.negate (vec_of_term x))))
       Lincons0.SUPEQ
-  | `Comparison (`Eq, x, y) ->
+  | `Arith_Comparison (`Eq, x, y) ->
     Lincons0.make
       (linexpr_of_vec
          (V.add (vec_of_term y) (V.negate (vec_of_term x))))
       Lincons0.EQ
-  | `Literal (_, _) -> assert false
+  | `Literal (_, _) 
+  | `Arr_Comparison _ -> assert false
 
 let meet_atoms wedge atoms =
   (* Ensure that the coordinate system admits each atom *)
   atoms |> List.iter (fun atom ->
       match Interpretation.destruct_atom wedge.srk atom with
-      | `Comparison (_, x, y) ->
+      | `Arith_Comparison (_, x, y) ->
         CS.admit_term wedge.cs x;
         CS.admit_term wedge.cs y
-      | `Literal (_, _) -> assert false);
+      | `Literal (_, _) 
+      | `Arr_Comparison _ -> assert false);
   update_env wedge;
   let abstract =
     atoms
@@ -1304,10 +1306,11 @@ let of_atoms srk atoms =
   let cs = CS.mk_empty srk in
   let register_terms atom =
     match Interpretation.destruct_atom srk atom with
-    | `Comparison (_, x, y) ->
+    | `Arith_Comparison (_, x, y) ->
       CS.admit_term cs x;
       CS.admit_term cs y
-    | `Literal (_, _) -> assert false
+    | `Literal (_, _) 
+    | `Arr_Comparison _ -> assert false
   in
   List.iter register_terms atoms;
   let env = mk_env cs in
@@ -1345,10 +1348,11 @@ let common_cs wedge wedge' =
   let cs = CS.mk_empty srk in
   let register_terms atom =
     match Interpretation.destruct_atom srk atom with
-    | `Comparison (_, x, y) ->
+    | `Arith_Comparison (_, x, y) ->
       CS.admit_term cs x;
       CS.admit_term cs y
-    | `Literal (_, _) -> assert false
+    | `Literal (_, _) 
+    | `Arr_Comparison _ -> assert false
   in
   let atoms = to_atoms wedge in
   let atoms' = to_atoms wedge' in

--- a/srk/src/wedge.ml
+++ b/srk/src/wedge.ml
@@ -15,6 +15,7 @@ module CS = CoordinateSystem
 module A = BatDynArray
 
 module IntSet = SrkUtil.Int.Set
+module Term = ArithTerm
 
 include Log.Make(struct let name = "srk.wedge" end)
 
@@ -1968,8 +1969,9 @@ let is_sat srk phi =
     Symbol.Map.enum nonlinear
     /@ (fun (symbol, expr) ->
         match Expr.refine srk expr with
-        | `Term t -> mk_eq srk (mk_const srk symbol) t
-        | `Formula phi -> mk_iff srk (mk_const srk symbol) phi)
+        | `ArithTerm t -> mk_eq srk (mk_const srk symbol) t
+        | `Formula phi -> mk_iff srk (mk_const srk symbol) phi
+        | `ArrTerm _ -> assert false)
     |> BatList.of_enum
   in
   let nonlinear = Symbol.Map.map (Nonlinear.interpret srk) nonlinear in
@@ -2084,8 +2086,9 @@ let abstract_subwedge subwedge ?exists:(p=fun _ -> true) ?(subterm=fun _ -> true
     Symbol.Map.enum nonlinear
     /@ (fun (symbol, expr) ->
         match Expr.refine srk expr with
-        | `Term t -> mk_eq srk (mk_const srk symbol) t
-        | `Formula phi -> mk_iff srk (mk_const srk symbol) phi)
+        | `ArithTerm t -> mk_eq srk (mk_const srk symbol) t
+        | `Formula phi -> mk_iff srk (mk_const srk symbol) phi
+        | `ArrTerm _ -> assert false)
     |> BatList.of_enum
     |> mk_and srk
   in
@@ -2164,8 +2167,9 @@ let abstract_subwedge_weak subwedge srk phi =
     Symbol.Map.enum nonlinear
     /@ (fun (symbol, expr) ->
         match Expr.refine srk expr with
-        | `Term t -> mk_eq srk (mk_const srk symbol) t
-        | `Formula phi -> mk_iff srk (mk_const srk symbol) phi)
+        | `ArithTerm t -> mk_eq srk (mk_const srk symbol) t
+        | `Formula phi -> mk_iff srk (mk_const srk symbol) phi
+        | `ArrTerm _ -> assert false)
     |> BatList.of_enum
     |> mk_and srk
   in

--- a/srk/src/wedge.mli
+++ b/srk/src/wedge.mli
@@ -49,15 +49,15 @@ val is_top : 'a t -> bool
     interpretation of this representation is that for any vector v,
     [wedge |= (vector0 . v) term0 + ... + (vectorn . v) termn = 0]
     where [.] represents the dot product. *)
-val farkas_equalities : 'a t -> ('a term * Linear.QQVector.t) list
+val farkas_equalities : 'a t -> ('a arith_term * Linear.QQVector.t) list
 
 (** Given a wedge [wedge] and a symbol [symbol], compute a list of lower bounds
     and upper bounds for [symbol] that are implied by [wedge]. *)
-val symbolic_bounds : 'a t -> symbol -> ('a term) list * ('a term) list
+val symbolic_bounds : 'a t -> symbol -> ('a arith_term) list * ('a arith_term) list
 
 (** Given a wedge [wedge] and a term [term], compute a lower and upper bounds
     for [term] within the region [wedge]. *)
-val bounds : 'a t -> 'a term -> Interval.t
+val bounds : 'a t -> 'a arith_term -> Interval.t
 
 (** Ensure that a context has named [max] and [min] symbols.  If the symbols
     are not present in the context [ensure_max_min] registers them. *)
@@ -121,7 +121,7 @@ val symbolic_bounds_formula : ?exists:(symbol -> bool) ->
   'a context ->
   'a formula ->
   symbol ->
-  [ `Sat of (('a term) option * ('a term) option) | `Unsat ]
+  [ `Sat of (('a arith_term) option * ('a arith_term) option) | `Unsat ]
 
 (** As [symbolic_bounds_formula], execept the lower bound is
    represented as a min of maxes, and the upper bound is represented
@@ -130,7 +130,7 @@ val symbolic_bounds_formula_list : ?exists:(symbol -> bool) ->
   'a context ->
   'a formula ->
   symbol ->
-  [ `Sat of (('a term) list list) * (('a term) list list) | `Unsat ]
+  [ `Sat of (('a arith_term) list list) * (('a arith_term) list list) | `Unsat ]
 
 val coordinate_system : 'a t -> 'a CoordinateSystem.t
 

--- a/srk/test/test_apron.ml
+++ b/srk/test/test_apron.ml
@@ -1,6 +1,5 @@
 open Srk
 open OUnit
-open Syntax
 open SrkApron
 open Test_pervasives
 
@@ -12,7 +11,7 @@ let roundtrip1 () =
     (x + y) / (int 5) + ((int 2) * x)
   in
   let t2 = term_of_texpr env (texpr_of_term env t) in
-  assert_equal ~cmp:Term.equal ~printer:(Term.show srk) t t2
+  assert_equal_arith_term t t2
 
 let roundtrip2 () =
   let t =
@@ -20,7 +19,7 @@ let roundtrip2 () =
     Ctx.mk_floor ((x + y) / (((int 2) / (int 5)) + z)) + (int 1)
   in
   let t2 = term_of_texpr env (texpr_of_term env t) in
-  assert_equal ~cmp:Term.equal ~printer:(Term.show srk) t t2
+  assert_equal_arith_term t t2
 
 let roundtrip3 () = 
   let t =
@@ -28,7 +27,7 @@ let roundtrip3 () =
     Ctx.mk_mod (x + (int 5)) (int 2)
   in
   let t2 = term_of_texpr env (texpr_of_term env t) in
-  assert_equal ~cmp:Term.equal ~printer:(Term.show srk) t t2
+  assert_equal_arith_term t t2
 
 module Vec = Linear.QQVector
 let roundtrip4 () =

--- a/srk/test/test_pervasives.ml
+++ b/srk/test/test_pervasives.ml
@@ -11,13 +11,16 @@ let formula_of_z3 = SrkZ3.formula_of_z3 srk
 let z3_of_formula = SrkZ3.z3_of_formula srk z3
 let term_of_z3 = SrkZ3.term_of_z3 srk
 let z3_of_term = SrkZ3.z3_of_term srk z3
+let z3_of_arith_term = SrkZ3.z3_of_arith_term srk z3
+let z3_of_arr_term = SrkZ3.z3_of_arr_term srk z3
+
 
 let qsym = Ctx.mk_symbol ~name:"q" `TyReal
 let rsym = Ctx.mk_symbol ~name:"r" `TyReal
 let ssym = Ctx.mk_symbol ~name:"s" `TyReal
-let q : 'a term = Ctx.mk_const qsym
-let r : 'a term = Ctx.mk_const rsym
-let s : 'a term = Ctx.mk_const ssym
+let q : 'a arith_term = Ctx.mk_const qsym
+let r : 'a arith_term = Ctx.mk_const rsym
+let s : 'a arith_term = Ctx.mk_const ssym
 
 let vsym = Ctx.mk_symbol ~name:"v" `TyInt
 let wsym = Ctx.mk_symbol ~name:"w" `TyInt
@@ -30,19 +33,26 @@ let xsym' = Ctx.mk_symbol ~name:"x'" `TyInt
 let ysym' = Ctx.mk_symbol ~name:"y'" `TyInt
 let zsym' = Ctx.mk_symbol ~name:"z'" `TyInt
 
-let v : 'a term = Ctx.mk_const vsym
-let w : 'a term = Ctx.mk_const wsym
-let x : 'a term = Ctx.mk_const xsym
-let y : 'a term = Ctx.mk_const ysym
-let z : 'a term = Ctx.mk_const zsym
-let v' : 'a term = Ctx.mk_const vsym'
-let w' : 'a term = Ctx.mk_const wsym'
-let x' : 'a term = Ctx.mk_const xsym'
-let y' : 'a term = Ctx.mk_const ysym'
-let z' : 'a term = Ctx.mk_const zsym'
+let v : 'a arith_term = Ctx.mk_const vsym
+let w : 'a arith_term = Ctx.mk_const wsym
+let x : 'a arith_term = Ctx.mk_const xsym
+let y : 'a arith_term = Ctx.mk_const ysym
+let z : 'a arith_term = Ctx.mk_const zsym
+let v' : 'a arith_term = Ctx.mk_const vsym'
+let w' : 'a arith_term = Ctx.mk_const wsym'
+let x' : 'a arith_term = Ctx.mk_const xsym'
+let y' : 'a arith_term = Ctx.mk_const ysym'
+let z' : 'a arith_term = Ctx.mk_const zsym'
+
+let a1sym = Ctx.mk_symbol ~name:"a1" `TyArr
+let a2sym = Ctx.mk_symbol ~name:"a2" `TyArr
+let a3sym = Ctx.mk_symbol ~name:"a3" `TyArr
+let a1 = Ctx.mk_const a1sym
+let a2 = Ctx.mk_const a2sym
+let a3 = Ctx.mk_const a3sym
 
 let fsym = Ctx.mk_symbol ~name:"f" (`TyFun ([`TyInt], `TyInt))
-let f : Ctx.term -> Ctx.term =
+let f : Ctx.arith_term -> Ctx.arith_term =
   fun x -> Ctx.mk_app fsym [(x :> (Ctx.t, typ_fo) expr)]
 
 let frac num den = Ctx.mk_real (QQ.of_frac num den)
@@ -72,8 +82,11 @@ let mk_qqmatrix mat =
     QQMatrix.zero
     (List.mapi (fun i row -> (i, mk_qqvector row)) mat)
 
+let assert_equal_arith_term s t =
+  assert_equal ~cmp:ArithTerm.equal ~printer:(ArithTerm.show srk) s t
+
 let assert_equal_term s t =
-  assert_equal ~printer:(Term.show srk) s t
+  assert_equal ~cmp:Term.equal ~printer:(Term.show srk) s t
 
 let assert_equal_formula s t =
   assert_equal ~printer:(Formula.show srk) s t

--- a/srk/test/test_smt.ml
+++ b/srk/test/test_smt.ml
@@ -6,18 +6,18 @@ open Test_pervasives
 let b = Ctx.mk_const (Ctx.mk_symbol ~name:"b" `TyBool)
 
 let gsym = Ctx.mk_symbol ~name:"g" (`TyFun ([`TyInt; `TyInt], `TyInt))
-let g : Ctx.term * Ctx.term -> Ctx.term =
+let g : Ctx.arith_term * Ctx.arith_term -> Ctx.arith_term =
   fun (x, y) -> Ctx.mk_app gsym [x; y]
 
 let fsym = Ctx.mk_symbol ~name:"f" (`TyFun ([`TyInt; `TyBool], `TyInt))
-let f : Ctx.term * Ctx.formula -> Ctx.term =
+let f : Ctx.arith_term * Ctx.formula -> Ctx.arith_term =
   fun (x, y) -> Ctx.mk_app fsym [(x :> (Ctx.t, typ_fo) expr);
                                  (y :> (Ctx.t, typ_fo) expr)]
 
 let p = Ctx.mk_symbol ~name:"p" (`TyFun ([`TyInt; `TyBool], `TyBool))
 
 let hsym = Ctx.mk_symbol ~name:"h" (`TyFun ([`TyReal; `TyReal], `TyReal))
-let h : Ctx.term * Ctx.term -> Ctx.term =
+let h : Ctx.arith_term * Ctx.arith_term -> Ctx.arith_term =
   fun (x, y) -> Ctx.mk_app hsym [x; y]
 
 let roundtrip0 () =
@@ -31,7 +31,7 @@ let roundtrip1 () =
     let open Infix in
     x * x * x mod (int 10) + (frac 100 3) / (r - z + s)
   in
-  assert_equal_term term (term_of_z3 (z3_of_term term))
+  assert_equal_term (term :> 'a term) (term_of_z3 (z3_of_arith_term term))
 
 let roundtrip2 () =
   let phi =
@@ -58,7 +58,14 @@ let roundtrip4 () =
     let open Infix in
     (f (x, b)) + x
   in
-  assert_equal_term term (term_of_z3 (z3_of_term term))
+  assert_equal_term (term :> 'a term) (term_of_z3 (z3_of_arith_term term))
+
+let roundtrip5 () =
+  let formula =
+    let open Infix in
+    mk_forall_const srk a1sym ((( a1.%[x]<-y).%[y]<-z).%[(int 5)] = (int 5))
+  in
+  assert_equal_formula formula (formula_of_z3 (z3_of_formula formula))
 
 let is_interpolant phi psi itp =
   (Smt.entails srk phi itp = `Yes)
@@ -327,6 +334,7 @@ let suite = "SMT" >:::
     "roundtrip2" >:: roundtrip2;
     "roundtrip3" >:: roundtrip3;
     "roundtrip4" >:: roundtrip4;
+    "roundtrip5" >:: roundtrip5;
 (*
     "interpolate1" >:: interpolate1;
     "interpolate2" >:: interpolate2;

--- a/srk/test/test_syntax.ml
+++ b/srk/test/test_syntax.ml
@@ -146,6 +146,49 @@ let elim_ite3 () =
   in
   assert_equiv_formula (eliminate_ite srk phi) phi
 
+let elim_stores1 () =
+  let phi =
+    let open Infix in
+    (a1.%[x]<-y) == a1
+  in
+  let lam =
+    let open Infix in
+    mk_forall 
+      srk
+      ~name:"K" 
+      `TyInt 
+      (Ctx.mk_ite (x = (var 0 `TyInt)) y (a1.%[(var 0 `TyInt)]) 
+       = a1.%[(var 0 `TyInt)])
+  in
+  assert_equal_formula (eliminate_stores srk phi) lam
+
+let elim_stores2 () =
+  let phi =
+    let open Infix in
+    (a1.%[(var 0 `TyInt)]<-y) == a1
+  in
+  let lam =
+    let open Infix in
+    mk_forall 
+      srk
+      ~name:"K" 
+      `TyInt 
+      (Ctx.mk_ite ((var 1 `TyInt) = (var 0 `TyInt)) y (a1.%[(var 0 `TyInt)]) 
+       = a1.%[(var 0 `TyInt)])
+  in
+  assert_equal_formula (eliminate_stores srk phi) lam
+
+let elim_stores3 () =
+  let phi =
+    let open Infix in
+    ((a1.%[x]<-x).%[x]) = x
+  in
+  let lam =
+    let open Infix in
+    (Ctx.mk_ite (x = x) x (a1.%[x]) = x)
+  in
+  assert_equal_formula (eliminate_stores srk phi) lam
+
 let suite = "Syntax" >:::
   [
     "substitute" >:: substitute;
@@ -158,6 +201,9 @@ let suite = "Syntax" >:::
     "elim_ite1" >:: elim_ite1;
     "elim_ite2" >:: elim_ite2;
     "elim_ite3" >:: elim_ite3;
+    "elim_stores1" >:: elim_stores1;
+    "elim_stores2" >:: elim_stores2;
+    "elim_stores3" >:: elim_stores3;
     "env1" >:: (fun () ->
       let e = List.fold_right Env.push [1;2;3;4;5] Env.empty in
       (0 -- 4) |> BatEnum.iter (fun i ->

--- a/srk/test/test_syntax.ml
+++ b/srk/test/test_syntax.ml
@@ -146,49 +146,6 @@ let elim_ite3 () =
   in
   assert_equiv_formula (eliminate_ite srk phi) phi
 
-let elim_stores1 () =
-  let phi =
-    let open Infix in
-    (a1.%[x]<-y) == a1
-  in
-  let lam =
-    let open Infix in
-    mk_forall 
-      srk
-      ~name:"K" 
-      `TyInt 
-      (Ctx.mk_ite (x = (var 0 `TyInt)) y (a1.%[(var 0 `TyInt)]) 
-       = a1.%[(var 0 `TyInt)])
-  in
-  assert_equal_formula (eliminate_stores srk phi) lam
-
-let elim_stores2 () =
-  let phi =
-    let open Infix in
-    (a1.%[(var 0 `TyInt)]<-y) == a1
-  in
-  let lam =
-    let open Infix in
-    mk_forall 
-      srk
-      ~name:"K" 
-      `TyInt 
-      (Ctx.mk_ite ((var 1 `TyInt) = (var 0 `TyInt)) y (a1.%[(var 0 `TyInt)]) 
-       = a1.%[(var 0 `TyInt)])
-  in
-  assert_equal_formula (eliminate_stores srk phi) lam
-
-let elim_stores3 () =
-  let phi =
-    let open Infix in
-    ((a1.%[x]<-x).%[x]) = x
-  in
-  let lam =
-    let open Infix in
-    (Ctx.mk_ite (x = x) x (a1.%[x]) = x)
-  in
-  assert_equal_formula (eliminate_stores srk phi) lam
-
 let suite = "Syntax" >:::
   [
     "substitute" >:: substitute;
@@ -201,9 +158,6 @@ let suite = "Syntax" >:::
     "elim_ite1" >:: elim_ite1;
     "elim_ite2" >:: elim_ite2;
     "elim_ite3" >:: elim_ite3;
-    "elim_stores1" >:: elim_stores1;
-    "elim_stores2" >:: elim_stores2;
-    "elim_stores3" >:: elim_stores3;
     "env1" >:: (fun () ->
       let e = List.fold_right Env.push [1;2;3;4;5] Env.empty in
       (0 -- 4) |> BatEnum.iter (fun i ->

--- a/srk/test/test_wedge.ml
+++ b/srk/test/test_wedge.ml
@@ -11,8 +11,8 @@ let (pow, log) =
   (get_named_symbol srk "pow",
    get_named_symbol srk "log")
 
-let mk_log (base : 'a term) (x : 'a term) = mk_app srk log [base; x]
-let mk_pow (base : 'a term) (exp : 'a term) = mk_app srk pow [base; exp]
+let mk_log (base : 'a arith_term) (x : 'a arith_term) = mk_app srk log [base; x]
+let mk_pow (base : 'a arith_term) (exp : 'a arith_term) = mk_app srk pow [base; exp]
 
 let assert_implies phi psi =
   psi |> List.iter (fun atom ->
@@ -32,8 +32,8 @@ let cs_roundtrip1 () =
   let yx = mk_mul srk [y; x] in
   CS.admit_term cs xy;
   CS.admit_term cs yx;
-  assert_equal_term xy (CS.term_of_vec cs (CS.vec_of_term cs xy));
-  assert_equal_term yx (CS.term_of_vec cs (CS.vec_of_term cs yx))
+  assert_equal_arith_term xy (CS.term_of_vec cs (CS.vec_of_term cs xy));
+  assert_equal_arith_term yx (CS.term_of_vec cs (CS.vec_of_term cs yx))
 
 let cs_roundtrip2 () =
   let cs = CoordinateSystem.mk_empty srk in
@@ -41,7 +41,7 @@ let cs_roundtrip2 () =
   let xx = mk_mul srk [x; x] in
   let fourxx = mk_mul srk [mk_real srk (QQ.of_int 4); xx] in
   CS.admit_term cs x4x;
-  assert_equal_term fourxx (CS.term_of_vec cs (CS.vec_of_term cs x4x))
+  assert_equal_arith_term fourxx (CS.term_of_vec cs (CS.vec_of_term cs x4x))
 
 let roundtrip1 () =
   let atoms =


### PR DESCRIPTION
This PR adds arrays as a first order type to srk.

Two things are notable missing from this PR

1) We discussed including select atoms in coordinate_systems. This changes seems like it might greatly complicate current code given coordinate_systems reliance on QQVectors.

2) No current support for interpretation of arrays