### PR TITLE
Support for sup-lin chc. Removed most normalization from srkZ3 parsin…

### DIFF
--- a/srk/src/chc.ml
+++ b/srk/src/chc.ml
@@ -1,414 +1,381 @@
 (* Constrained horn clauses *)
 open Syntax
-open BatPervasives
+(*open BatPervasives*)
 module DynArray = BatDynArray
 module D = Graph.Pack.Digraph
 module WG = WeightedGraph
 
-type relation = int
-type rel_atom = relation * symbol list
-type 'a fp = { mutable rules : (rel_atom list * 'a formula * rel_atom) list; 
-               mutable queries : relation list;
-               rel_ctx : (string * typ_fo list) DynArray.t } 
+type proposition = { symbol : symbol; names : string list }
+module Proposition = struct
+  (* Relation atoms have as parameters free variables. We maintain the invariant
+   * that these free variables be sequential. The int option in this type
+   * describes the debruijn index of the first parameter; it is `None` in the
+   * case that the atom has no parameters.*)
+  type t = proposition
+ 
+  let symbol_of prop  = prop.symbol
+  let names_of prop = prop.names
 
 
-let mk_relation fp ?(name="R") typ =
-  DynArray.add fp.rel_ctx (name, typ);
-  DynArray.length fp.rel_ctx - 1
-let type_of fp rel = snd (DynArray.get fp.rel_ctx rel)
-let name_of fp rel = fst (DynArray.get fp.rel_ctx rel)
+  let typ_of_params srk prop =
+    match typ_symbol srk prop.symbol with 
+    | `TyBool 
+    | `TyFun ([], `TyBool) -> []
+    | `TyFun (lst, `TyBool) -> lst
+    | _ -> assert false
 
-let rel_of_atom (relation, _) = relation
-let params_of_atom (_, params) = params
+  let prop_of srk prop init_index =
+    let params = 
+      BatList.mapi (fun ind typ ->
+          mk_var srk (ind + init_index) typ)
+        (typ_of_params srk prop)
+    in
+    mk_app srk (symbol_of prop) params
+
+  let mk_proposition srk symbol names =
+    match typ_symbol srk symbol with 
+    | `TyBool when BatList.is_empty names -> { symbol; names}
+    | `TyFun (typs, `TyBool) when List.length names = List.length typs ->
+      { symbol; names}
+    | _ -> invalid_arg "mk_proposition: ill-formed proposition"
+end
+
+ type 'a fp = { rules : (proposition * proposition list * 'a formula) list; 
+                queries : Symbol.Set.t }
 
 let typ_symbol_fo srk sym =
   match typ_symbol srk sym with
   | `TyInt -> `TyInt
   | `TyReal -> `TyReal
   | `TyBool -> `TyBool
+  | `TyArr -> `TyArr
   (* TODO: arrays *)
   | _ -> assert false
-
-let mk_rel_atom srk fp rel syms =
-  if ((type_of fp rel) = (List.map (typ_symbol_fo srk) syms))
-  then rel, syms
-  else invalid_arg "Type Error mk_rel_atom"
-
-module Relation = struct
-  type t = relation 
-  module Set = SrkUtil.Int.Set 
-  let compare = Stdlib.compare
-
-  let pp fp formatter rel =
-    Format.fprintf formatter "@%s:R%n@" (name_of fp rel) rel
-  let show fp = SrkUtil.mk_show (pp fp)
-end
-
-let pp_rel_atom srk fp formatter (rel, symbols) =
-    Format.fprintf formatter "%a(@[%a@])"
-      (Relation.pp fp) rel
-      (SrkUtil.pp_print_enum_nobox (pp_symbol srk)) (BatList.enum symbols)
-
-let show_rel_atom srk fp = 
-  SrkUtil.mk_show (pp_rel_atom srk fp)
 
 module Fp = struct
   type 'a t = 'a fp
 
-  let pp_hypothesis srk fp formatter (rel_atoms, phi) =
-    Format.fprintf formatter "(@[";
-    SrkUtil.pp_print_enum
-      ~pp_sep:(fun formatter () -> Format.fprintf formatter "@ /\\ ")
-      (pp_rel_atom srk fp)
-      formatter
-      (BatList.enum rel_atoms);
-    Format.fprintf formatter "@]/\\%a)" (Formula.pp srk) phi
-  let pp_rule srk fp formatter (rel_atoms, phi, conc) =
-    Format.fprintf formatter "(@[%a@ => %a@])"
-      (pp_hypothesis srk fp) (rel_atoms, phi)
-      (pp_rel_atom srk fp) conc
+  let pp_rule srk formatter (conc, hypo_props, phi) =
+    let body, _ =
+      List.fold_left (fun (phi, counter) prop -> 
+          mk_and srk [Proposition.prop_of srk prop counter; phi], 
+          counter + List.length (Proposition.typ_of_params srk prop)) 
+        (phi, List.length (Proposition.typ_of_params srk conc))
+        hypo_props
+    in
+    let pre_quantified = mk_if srk body (Proposition.prop_of srk conc 0) in
+    let phi = 
+      List.fold_left (fun phi prop ->
+          BatList.fold_left2 (fun phi typ name ->
+              mk_forall srk ~name:name typ phi)
+            phi
+            (Proposition.typ_of_params srk prop)
+            (Proposition.names_of prop))
+        pre_quantified
+        (conc :: hypo_props)
+    in
+    Formula.pp srk formatter phi
 
   let pp srk formatter fp = 
     Format.fprintf formatter "(Rules:\n@[";
     SrkUtil.pp_print_enum
       ~pp_sep:(fun formatter () -> Format.fprintf formatter "@ \n ")
-      (pp_rule srk fp)
+      (pp_rule srk)
       formatter
       (BatList.enum fp.rules);
     Format.fprintf formatter "@]\nQueries:@[%a@])"
-      (SrkUtil.pp_print_enum_nobox (Relation.pp fp)) 
-      (BatList.enum fp.queries)
+      (SrkUtil.pp_print_enum_nobox (pp_symbol srk)) 
+      (Symbol.Set.enum fp.queries)
 
   let show srk = SrkUtil.mk_show (pp srk)
 
-  let create () = {rules=[];queries=[];rel_ctx=(DynArray.create ())}
+  let empty = {rules=[];queries=Symbol.Set.empty}
 
-  let add_rule fp hypo phi conc = fp.rules <- (hypo, phi, conc) :: fp.rules 
+  let add_rule fp conc hypo phi = { fp with rules = (conc, hypo, phi) :: fp.rules} 
 
-  let add_query fp query = fp.queries <- query :: fp.queries 
-
-  let get_active_relations fp =
-    List.fold_left
-      (fun rset (hypo_atoms, _, conc_atom) ->
-         List.fold_left
-           (fun rset rel_atom -> Relation.Set.add (rel_of_atom rel_atom) rset)
-           (Relation.Set.add (rel_of_atom conc_atom) rset)
-           hypo_atoms)
-      (List.fold_left 
-         (fun rset query -> Relation.Set.add query rset)
-         Relation.Set.empty
-         fp.queries)
-      fp.rules
-
-  let get_relations_declared fp =
-    BatList.of_enum (0 -- ((DynArray.length fp.rel_ctx) - 1))
-
-  let is_linear rules =
-    BatList.fold_left 
-      (fun acc (hypo_atoms, _, _) -> acc && (List.length hypo_atoms) <= 1)
-      true
-      rules
-
-  let mk_eq_by_sort srk s1 s2 =
-    assert (typ_symbol srk s1 = typ_symbol srk s2);
-    match typ_symbol_fo srk s1 with
-    | `TyInt | `TyReal -> mk_eq srk (mk_const srk s1) (mk_const srk s2)
-    | `TyBool -> mk_iff srk (mk_const srk s1) (mk_const srk s2)
-
-  let normalize srk fp =
-    let rules' =
-      List.map (fun (hypos, constr, conc) ->
-          let update_atom (atom, eqs, syms) =
-            let params, eqs, syms =
-              List.fold_right
-                (fun param (params, eqs, syms) ->
-                   if not (Symbol.Set.mem param syms) then
-                     param :: params, eqs, (Symbol.Set.add param syms)
-                   else
-                     let s = dup_symbol srk param in
-                     let eq = mk_eq_by_sort srk s param in
-                     s :: params, eq :: eqs, Symbol.Set.add s syms)
-                (params_of_atom atom) 
-                ([], eqs, syms)
-            in
-            let atom' = mk_rel_atom srk fp (rel_of_atom atom) params in
-            atom', eqs, syms
-          in
-          let (hypos', eqs, syms) =
-            List.fold_left 
-              (fun (hypos', eqs, syms) hypo ->
-                 let atom', eqs', syms' = update_atom (hypo, eqs, syms) in
-                 atom' :: hypos', eqs', syms')
-              ([], [],  Symbol.Set.empty)
-              hypos
-          in
-          let (conc', eqs, syms) = update_atom (conc, eqs, syms) in
-          let constr' = 
-            mk_exists_consts 
-              srk 
-              (fun s -> Symbol.Set.mem s syms) 
-              (mk_and srk (constr :: eqs))
-          in
-          hypos', constr', conc')
-        fp.rules
-    in
-    {rules=rules'; queries=fp.queries; rel_ctx=fp.rel_ctx} 
-
+  let add_query fp query = { fp with queries = Symbol.Set.add query fp.queries} 
 
   let goal_vert = -2 
   let start_vert = -1
-  let emptyarr = BatArray.init 0 (fun _ -> failwith "empty")
 
-  let linchc_to_weighted_graph srk fp pd =
-    let fp = normalize srk fp in
+  let linchc_to_weighted_graph srk (fp : 'a t) pd =
     let open WeightedGraph in
-    (* The edges of the graph are of the form [(syms', syms', constr)] where 
-     * [syms] are the var symbols used in the hypothesis relation, [syms'] are
-     * those used in the conclusion relation, and [constr] in the constraint
-     * whose free variables are limited to [syms union syms']. Further, [syms]
-     * and [syms'] are always disjoint. *)
+    (* The edges of the graph are of the form 
+     * [(conc params, hypo params, constr)]*) 
     let alg = 
       let is_one (_, _, phi) = Formula.equal phi (mk_true srk) in
       let is_zero (_, _, phi) = Formula.equal phi (mk_false srk) in
-      let zero = emptyarr, emptyarr, mk_false srk in
-      let one = emptyarr, emptyarr, mk_true srk in
+      let zero = [], [], mk_false srk in
+      let one = [], [], mk_true srk in
       let add x y =
         if is_zero x then y else if is_zero y then x
-        else if is_one x || is_one y then one
         else (
-          let (prex, postx, phix) = x in
-          let (prey, posty, phiy) = y in
-          let rhs_new = 
-            substitute_sym 
-              srk
-              (fun sym ->
-                 try mk_const srk (prex.(BatArray.findi ((=) sym) prey))
-                 with Not_found -> 
-                   mk_const srk (postx.(BatArray.findi ((=) sym) posty)))
-              phiy
-          in
-          prex, postx, mk_or srk [phix; rhs_new])
+          let (fvc, fvh, phix) = x in
+          let (_, _, phiy) = y in
+          fvc, fvh, mk_or srk [phix; phiy])
       in
       let mul x y =
-        let (prex, postx, phix) = x in
-        let (prey, posty, phiy) = y in
-        if is_zero x || is_zero y then zero
-        else if is_one x then y else if is_one y then x
+        let (_, p_hx, phix) = x in
+        let (p_cy, p_hy, phiy) = y in
+        if is_one x then y else if is_one y then x
         else (
-          let pre' = Array.map (dup_symbol srk) prex in
-          let post' = Array.map (dup_symbol srk) posty in
-          let lhs_subst =
-            (fun sym ->
-               try mk_const srk (pre'.(BatArray.findi ((=) sym) prex))
-               with Not_found -> mk_const srk sym)
+          let num_p_cy, num_p_hy = List.length p_cy, List.length p_hy in
+          let phiy' = 
+            substitute
+              srk
+              (fun (ind, typ) ->
+                 if ind < num_p_cy
+                 then mk_var srk (ind + num_p_hy) typ
+                 else mk_var srk (ind - num_p_cy) typ)
+              phiy
           in
-          let rhs_subst = (fun sym ->
-              try mk_const srk (postx.(BatArray.findi ((=) sym) prey))
-              with Not_found -> 
-                mk_const srk (post'.(BatArray.findi ((=) sym) posty)))
+          let phix' =
+            substitute
+              srk
+              (fun (ind, typ) ->
+                 if ind < num_p_hy 
+                 then mk_var srk ind typ
+                 else mk_var srk (ind + num_p_cy) typ)
+              phix
           in
-          let phiy' = substitute_sym srk rhs_subst phiy in
-          let phix' = substitute_sym srk lhs_subst phix in
-          let phi' = 
-            mk_exists_consts 
-              srk 
-              (fun s -> not (Array.mem s postx)) 
-              (mk_and srk [phix'; phiy']) 
+          let phi' =
+            List.fold_left (fun phi (name, typ) ->
+                mk_exists srk ~name typ phi)
+              (mk_and srk [phix'; phiy'])
+              p_hy
           in
           (* TODO: try to remove the new quants via miniscoping/del procedure *)
-          pre', post', phi')
+          p_cy, p_hx, phi')
       in
-      let star (pre, post, phi) =
-        let module PD = (val pd : Iteration.PreDomain) in
-        let (trs, vars) =
-          BatArray.fold_lefti
-            (fun (trs, vars) ind presym -> 
-               (presym, post.(ind)) :: trs, presym :: post.(ind) :: vars)
-            ([], [])
-            pre
+      let star (p_c, p_h, phi) =
+        (* TODO: can use better data types more efficiently here *)
+        let skolems = symbols phi in
+        let exists sym = not (Symbol.Set.mem sym skolems) in 
+        let trs = 
+          List.map (fun (name, typ) ->
+              let s1 = mk_symbol srk ~name (typ :> typ) in
+              let s2 = mk_symbol srk ~name:(name^"'") (typ :> typ) in
+              s1, s2)
+            p_c
         in
+        let hypo_vars, conc_vars = List.split trs in
+        let vars = conc_vars @ hypo_vars in
+        let phi =
+          substitute
+            srk
+            (fun (ind, _) ->
+               if ind < List.length p_c
+               then mk_const srk (snd (List.nth trs ind))
+               else mk_const srk (fst (List.nth trs (ind - List.length p_c))))
+            phi
+        in
+        let module PD = (val pd : Iteration.PreDomain) in
         let lc = mk_symbol srk `TyInt in
-        let tf = TransitionFormula.make phi trs in
+        let tf = TransitionFormula.make ~exists phi trs in
         let phi' = PD.exp srk trs (mk_const srk lc) (PD.abstract srk tf) in
-        let phi' = mk_exists_consts srk (fun s -> List.mem s vars) phi' in
+        let trs_flat = List.flatten (List.map (fun (x, x') -> [x; x']) trs) in
+        let phi' = mk_exists_consts srk (fun s -> Symbol.Set.mem s skolems || List.mem s trs_flat) phi' in
+        let phi' =
+          substitute_sym 
+            srk
+            (fun sym ->
+              match BatList.index_of sym vars with
+              | Some i -> mk_var srk i (typ_symbol_fo srk sym)
+              | None -> mk_const srk sym)
+            phi'
+        in
         (* TODO: try to remove the new quants via miniscoping/del procedure *)
-        pre, post, phi' 
+        p_c, p_h, phi' 
       in
       {mul; add; star; zero; one}
     in
     let wg = WeightedGraph.add_vertex (WeightedGraph.empty alg) start_vert in
     let wg = WeightedGraph.add_vertex wg goal_vert in
-    let wg = 
-      List.fold_left 
-        (fun wg rel_sym -> WeightedGraph.add_vertex wg rel_sym)
-        wg
-        (get_relations_declared fp)
+    let prop_symbols =
+      BatList.fold_left (fun props (conc, hypo, _) ->
+          BatList.fold_left (fun props prop ->
+              Symbol.Set.add prop.symbol props)
+            props
+            (conc ::hypo))
+        fp.queries
+        fp.rules
     in
     let wg = 
+      Symbol.Set.fold (fun prop_sym wg -> 
+          WeightedGraph.add_vertex wg (int_of_symbol prop_sym))
+        prop_symbols
+        wg
+    in
+    let wg  = 
       List.fold_left
-        (fun wg (rel_atoms, phi, conc) ->
-           match rel_atoms with
+        (fun wg (conc, hypo_props, constr) ->
+           match hypo_props with
            | [] -> 
              WeightedGraph.add_edge 
                wg 
                start_vert
-               (emptyarr, BatArray.of_list (params_of_atom conc), phi)
-               (rel_of_atom conc)
+               (BatList.combine conc.names (Proposition.typ_of_params srk conc), [], constr)
+               (int_of_symbol conc.symbol)
            | [hd] -> 
              WeightedGraph.add_edge 
                wg
-               (rel_of_atom hd)
-               (BatArray.of_list (params_of_atom hd), 
-                BatArray.of_list (params_of_atom conc), 
-                phi)
-               (rel_of_atom conc)
+               (int_of_symbol hd.symbol)
+               (BatList.combine conc.names (Proposition.typ_of_params srk conc),
+                BatList.combine conc.names (Proposition.typ_of_params srk hd),
+                constr)
+               (int_of_symbol conc.symbol)
            | _ -> failwith "CHC is non-linear")
         wg
         fp.rules
     in
     let wg =
-      List.fold_left
-        (fun wg rel -> WeightedGraph.add_edge wg rel alg.one goal_vert)
-        wg
+      Symbol.Set.fold (fun sym wg ->
+          WeightedGraph.add_edge wg (int_of_symbol sym) alg.one goal_vert)
         fp.queries
+        wg
     in
     wg
 
-  let is_super_linear fp =
+  let stratify fp =
     (* Initialize graph: One vertex for each rel symbol.
      * There is an edge from rel a to rel b if a occurs in the
      * hypothesis of some rule for which b occurs in the conclusion.
      * A topological sort on the sccs of this graph will determine the
      * ordering on which we need to solve the relations.*)
-    let num_rels = (DynArray.length fp.rel_ctx) - 1 in
-    let verts = BatArray.init (num_rels + 1) D.V.create in
+    let prop_symbols =
+      BatList.fold_left (fun props (conc, hypo, _) ->
+          BatList.fold_left (fun props prop ->
+              Symbol.Set.add prop.symbol props)
+            props
+            (conc ::hypo))
+        fp.queries
+        fp.rules
+    in
+    let num_rels =  Symbol.Set.cardinal prop_symbols in
+    let verts = BatHashtbl.create 97 in
+    let inv_verts = BatHashtbl.create 97 in
+    Symbol.Set.iter (fun sym ->
+        let vert = D.V.create (int_of_symbol sym) in
+        BatHashtbl.add verts sym vert;
+        BatHashtbl.add inv_verts vert sym)
+      prop_symbols; 
     let graph = D.create () in
-    BatArray.iter (fun v -> D.add_vertex graph v) verts;
-    BatList.iter (fun (hypo_atoms, _, conc_atom) ->
-        List.iter (fun hatom ->
+    BatHashtbl.iter (fun _ v -> D.add_vertex graph v) verts;
+    BatList.iter (fun (conc, hypo, _) ->
+        List.iter (fun h_prop ->
             D.add_edge 
               graph 
-              (verts.(rel_of_atom hatom)) 
-              (verts.(rel_of_atom conc_atom)))
-          hypo_atoms)
+              (BatHashtbl.find verts h_prop.symbol) 
+              (BatHashtbl.find verts conc.symbol))
+          hypo)
       fp.rules;
     (* We create a new graph in which each scc is collapsed to
      * a single node and there is an edge from scc a to scc b
      * iff scc b was reachable from scc a in the original graph*)
-    let sccs = D.Components.scc_array graph in
-    let scc_rep = Array.map (fun scc ->  List.hd scc) sccs in
-    let path_check = D.PathCheck.create graph in
-    let sccverts = BatArray.init (Array.length sccs) D.V.create in
-    let sccgraph = D.create () in
-    BatArray.iter (fun v -> D.add_vertex sccgraph v) sccverts;
-    BatArray.iteri (fun scc1 rel1 ->
-        BatArray.iteri (fun scc2 rel2 ->
-            if D.PathCheck.check_path path_check rel1 rel2 then
-              D.add_edge sccgraph (sccverts.(scc1)) (sccverts.(scc2))
-            else ())
-          scc_rep)
-      scc_rep;
-    let solved = Hashtbl.create (num_rels + 1) in
+    let sccs = D.Components.scc_list graph in
+    let solved = Hashtbl.create num_rels in
     (* We compute a topologoical sort on the collapsed graph determine
      * if the collapsed graph forms a stratified lin system of chcs.*)
-    let (ordering, is_strat) = 
-      D.Topological.fold (fun scc_num (ordering, is_stratifiable) ->
+    let (ordering, is_strat) =
+      BatList.fold_left (fun (ordering, is_strat) verts ->
           (* First we extract the sub-chc *)
-          let of_vert arr v = BatArray.findi ((=) v) arr in
-          let rels = 
-            Relation.Set.of_list 
-              (List.map (of_vert verts) sccs.(of_vert sccverts scc_num)) 
-          in
-          let ordering' = rels :: ordering in
+          let props = Symbol.Set.of_list (List.map (BatHashtbl.find inv_verts) verts) in
+          let ordering' = props :: ordering in
           let ruleset = 
-            List.filter (fun (_, _, conc_atom) ->
-                Relation.Set.mem (rel_of_atom conc_atom) rels)
+            List.filter (fun (conc, _, _) -> 
+                Symbol.Set.mem conc.symbol props)
               fp.rules
           in
-          let is_stratifiable' = List.fold_left (fun acc (hypo_atoms, _, _) ->
-              if List.length (List.filter (fun atom ->
-                  not (Hashtbl.mem solved (rel_of_atom atom)))
-                  hypo_atoms) > 1
-              then false
+          let is_strat' = List.fold_left (fun acc (_, hypo_props, _) ->
+              if List.length (List.filter (fun prop ->
+                  not (Hashtbl.mem solved prop.symbol))
+                  hypo_props) > 1
+              then (false)
               else true && acc)
-              is_stratifiable
+              is_strat
               ruleset
           in
-          Relation.Set.iter 
+          Symbol.Set.iter 
             (fun rel -> Hashtbl.add solved rel ()) 
-            rels;
-          (ordering', is_stratifiable')
+            props;
+          (ordering', is_strat')
         )
-        sccgraph
         ([], true)
+        (List.rev sccs)
     in
     if is_strat then Some (List.rev ordering) else None
 
 
   let solve_super_lin srk fp pd ordering =
-    let fp = normalize srk fp in
-    let num_rels = (DynArray.length fp.rel_ctx) - 1 in
-    let solution = Hashtbl.create (num_rels + 1) in
+    let solution = Hashtbl.create 97 in
     (* We compute a topologoical sort on the collapsed graph and solve
      * for the relations in order.*)
     List.iter (fun rels ->
         let ruleset = 
-          List.filter (fun (_, _, conc_atom) ->
-              Relation.Set.mem (rel_of_atom conc_atom) rels)
+          List.filter (fun (conc, _, _) ->
+              Symbol.Set.mem conc.symbol rels)
             fp.rules
         in
         (* Substitute in the solutions for rels calculated at previous strata *)
-        let ruleset' = List.map (fun (hypo_atoms, constr, conc) ->
-            let hypo_atoms', constr' = 
-              List.fold_left (fun (hypo_atoms, constr) atom -> 
-                  if Hashtbl.mem solution (rel_of_atom atom) then (
-                    let syms, soln = Hashtbl.find solution (rel_of_atom atom) in
-                    let subst =
-                      (fun sym ->
-                         mk_const
-                           srk
-                           (List.nth
-                              (params_of_atom atom)
-                              (BatArray.findi ((=) sym) syms)))
+        let ruleset' = List.map (fun (conc, hypo_props, constr) ->
+            let hypo_atoms', constr', _ = 
+              List.fold_left (fun (hypo_atoms, constr, param_counter) prop -> 
+                  let num_params = List.length (Proposition.typ_of_params srk prop) in
+                  if Hashtbl.mem solution (int_of_symbol prop.symbol) then (
+                    let soln = Hashtbl.find solution (int_of_symbol prop.symbol) in
+                    let constr = 
+                      substitute
+                        srk
+                        (fun (ind, typ) ->
+                           if ind < param_counter
+                           then mk_var srk (ind + num_params) typ
+                           else if ind >= param_counter && ind < param_counter + num_params
+                           then mk_var srk (ind - param_counter) typ
+                           else mk_var srk ind typ)
+                        constr
                     in
-                    let soln = substitute_const srk subst soln in
-                    hypo_atoms, mk_and srk [soln; constr])
-                  else (atom :: hypo_atoms, constr))
-                ([], constr)
-                hypo_atoms
+                    let constr = mk_and srk [soln; constr] in
+                    let qs = BatList.combine prop.names (Proposition.typ_of_params srk prop) in
+                    let constr =
+                      BatList.fold_left (fun constr (name, typ) ->
+                          mk_exists srk ~name typ constr)
+                        constr
+                        qs
+                    in
+                    hypo_atoms, constr, param_counter)
+                  else (prop :: hypo_atoms, constr, param_counter + num_params))
+                ([], constr, List.length (Proposition.typ_of_params srk conc))
+                hypo_props
             in
-            hypo_atoms', constr', conc)
+            conc, List.rev hypo_atoms', constr')
             ruleset
         in
-        if is_linear ruleset' then (
-          let sub_fp = {rules=ruleset'; queries=[]; rel_ctx=fp.rel_ctx} in
-          let wg = linchc_to_weighted_graph srk sub_fp pd in
-          let sub_soln = 
-            (fun rel -> 
-               let _, params, phi = WG.path_weight wg start_vert rel in 
-               params, phi) 
-          in
-          Relation.Set.iter 
-            (fun rel -> Hashtbl.add solution rel (sub_soln rel)) 
-            rels)
-        else (invalid_arg "Chc not super-linear"))
+        let sub_fp = {rules=ruleset'; queries=Symbol.Set.empty} in
+        let wg = linchc_to_weighted_graph srk sub_fp pd in
+        let sub_soln = 
+          (fun rel -> 
+             let _, _, phi = WG.path_weight wg start_vert rel in 
+             phi) 
+        in
+        Symbol.Set.iter 
+          (fun rel -> Hashtbl.add solution (int_of_symbol rel) (sub_soln (int_of_symbol rel))) 
+          rels)
       ordering;
     let goal = 
       mk_or 
         srk 
-        (List.map (fun rel -> snd (Hashtbl.find solution rel)) fp.queries) 
+        (List.map (fun rel -> (Hashtbl.find solution (int_of_symbol rel))) (Symbol.Set.to_list fp.queries))
     in
-    Hashtbl.add solution goal_vert (emptyarr, goal);  
+    Hashtbl.add solution goal_vert goal;  
     Hashtbl.find solution
 
 
   let query_vc_condition srk fp pd =
-    match is_super_linear fp with
+    match stratify fp with
     | None -> failwith "No methods for solving non super linear chc systems"
     | Some ordering ->
       let res = solve_super_lin srk fp pd ordering in
-      let _, phi = res goal_vert in   
-      phi
+      res goal_vert   
 
   let check srk fp pd =
     let phi = query_vc_condition srk fp pd in
@@ -418,215 +385,193 @@ module Fp = struct
       | `Sat -> `Unknown
 
   let solve srk fp pd =
-    match is_super_linear fp with
+    match stratify fp with
     | None -> failwith "No methods for solving non lin fp"
     | Some ordering -> solve_super_lin srk fp pd ordering
 
-  let unbooleanize srk fp =
-    let fp' = create () in
-    let rel_map = BatHashtbl.create (List.length (get_relations_declared fp)) in
-    List.iter (fun rel ->
-        let typ' = 
-          List.map (fun typ -> 
-              if typ = `TyBool then `TyInt else typ) 
-            (type_of fp rel)
-        in
-        let rel' = mk_relation fp' ~name:(name_of fp rel) typ' in
-        BatHashtbl.add rel_map rel rel')
-      (get_relations_declared fp);
-    List.iter (fun (hypos, phi, conc) ->
-        let sym_map = BatHashtbl.create 97 in
-        let map_atom atom =
-          let params' = 
-            List.map (fun param ->
-                if typ_symbol srk param = `TyBool then (
-                  if BatHashtbl.mem sym_map param then
-                    BatHashtbl.find sym_map param
-                  else
-                    let param' = mk_symbol srk ~name:(show_symbol srk param) `TyInt in
-                    BatHashtbl.add sym_map param param';
-                    param')
-                else
-                  param)
-              (params_of_atom atom)
-          in
-          let rel' = BatHashtbl.find rel_map (rel_of_atom atom) in
-          mk_rel_atom srk fp' rel' params'
-        in
-        let hypos' = List.map map_atom hypos in
-        let conc' = map_atom conc in
-        let phi_subst = 
-          substitute_const 
-            srk
-            (fun s -> 
-               if BatHashtbl.mem sym_map s then
-                 mk_eq srk (mk_one srk) (mk_const srk (BatHashtbl.find sym_map s))
-               else
-                 mk_const srk s)
-            phi
-        in
-        let bool_constrs =
-          BatHashtbl.fold (fun _ sym acc -> 
-              mk_or 
-                srk 
-                [mk_eq srk (mk_const srk sym) (mk_one srk);
-                 mk_eq srk (mk_const srk sym) (mk_zero srk)] :: acc)
-            sym_map
-            []
-        in
-        let phi' = mk_and srk (phi_subst :: bool_constrs) in
-        add_rule fp' hypos' phi' conc')
-      fp.rules;
-    List.iter (fun rel -> 
-        add_query fp' (BatHashtbl.find rel_map rel)) 
-      fp.queries;
-    let rel_fun rel = BatHashtbl.find rel_map rel in
-    rel_fun, fp'
 end
 
 module ChcSrkZ3 = struct
-  
+  open SrkZ3
+
   let typ_of_sort sort =
     let open Z3enums in
     match Z3.Sort.get_sort_kind sort with
     | REAL_SORT -> `TyReal
     | INT_SORT -> `TyInt
     | BOOL_SORT -> `TyBool
-    (*| ARRAY_SORT -> `TyArr*)
-    |_ -> failwith "function types not currently supported in rel param"
+    | ARRAY_SORT -> `TyArr
+    | _ -> invalid_arg "typ_of_sort"
 
-  let rel_atom_of_z3 srk fp ind_to_sym rsym_to_int z3pred =
-    let eqs = ref [] in
-    let args = List.map 
-        (fun arg ->
-           begin match Z3.AST.get_ast_kind (Z3.Expr.ast_of_expr arg) with
-             | VAR_AST ->
-               let index = Z3.Quantifier.get_index arg in
-               BatHashtbl.find ind_to_sym index
-               (* Logic for handling case if rel atom arg is a numerical
-                * or logical constant *)
-             | NUMERAL_AST ->
-               let sym = mk_symbol srk `TyInt in
-               let q = SrkZ3.term_of_z3 srk arg in
-               eqs := (mk_eq srk (mk_const srk sym) q) :: !eqs;
-               sym
-             | APP_AST -> 
-               let decl = Z3.Expr.get_func_decl arg in
-               begin match Z3.FuncDecl.get_decl_kind decl with
-               | OP_TRUE ->
-                 let sym = mk_symbol srk `TyBool in
-                 eqs := (mk_const srk sym) :: !eqs;
-                 sym
-               | OP_FALSE -> 
-                 let sym = mk_symbol srk `TyBool in
-                 eqs := (mk_not srk (mk_const srk sym)) :: !eqs;
-                 sym
-               | _ -> invalid_arg "Cannot have non-trivial terms as param to relation"
-               end
-             | _ -> assert false
-           end) 
-        (Z3.Expr.get_args z3pred) in
-    let decl = Z3.Expr.get_func_decl z3pred in
-    let rsym = Z3.Symbol.to_string (Z3.FuncDecl.get_name decl) in
-    let relation = 
-      if Hashtbl.mem rsym_to_int rsym then Hashtbl.find rsym_to_int rsym
-      else (
-        let typ = List.map (fun arg -> typ_symbol_fo srk arg) args in
-        let res = mk_relation fp ~name:rsym typ in
-        Hashtbl.add rsym_to_int rsym res;
-        res)
+
+  let parse_z3fp ?(z3queries=[]) srk z3fp =
+    let cos =
+      Memo.memo (fun (name, typ) ->
+          mk_symbol srk ~name typ)
     in
-    (relation, args), !eqs
-
-  let parse_z3fp ?(z3queries=[]) srk fp z3fp =
-    let rsym_to_int = BatHashtbl.create 91 in
-    let decl_kind e = Z3.FuncDecl.get_decl_kind (Z3.Expr.get_func_decl e) in
+    let sym_of_decl =
+      fun decl ->
+        let open Z3 in
+        let sym = FuncDecl.get_name decl in
+        match FuncDecl.get_domain decl with
+        | [] ->
+          cos (Symbol.to_string sym, typ_of_sort (FuncDecl.get_range decl))
+        | dom ->
+          let typ =
+            `TyFun (List.map typ_of_sort dom,
+                    typ_of_sort (FuncDecl.get_range decl))
+          in
+          cos (Symbol.to_string sym, typ)
+    in
+    let rec detach_qpf qnf_phi : (string * typ_fo) list * 'a formula =
+      match Formula.destruct srk qnf_phi with
+      | `Quantify (`Forall, name, typ, phi) -> 
+        let qts, phi = detach_qpf phi in
+        (name, typ) :: qts, phi
+      | `Quantify (`Exists, _, _, _) -> assert false
+      | matrix -> [], Formula.construct srk matrix
+    in
+    let detach_conc matrix = 
+      match Formula.destruct srk matrix with
+      | `Proposition (`App (f, args)) -> mk_true srk, (f, args)
+      | `Or [n_hypo; conc] ->
+        begin match Formula.destruct srk n_hypo, Formula.destruct srk conc with
+          | `Not hypo, `Proposition (`App (f, args)) -> hypo, (f, args)
+          | _ -> assert false
+        end
+      | _ -> assert false
+    in
+    let detach_hypo_props hypo =
+      match Formula.destruct srk hypo with
+      | `Proposition (`App (f, args)) -> [(f, args)], mk_true srk
+      | `And conjs ->
+        let (props, constr_conjs) = 
+          BatList.partition_map (fun conj -> 
+               match Formula.destruct srk conj with
+               | `Proposition (`App (f, args)) -> Left (f, args)
+               | phi -> Right (Formula.construct srk phi))
+            conjs 
+        in
+        props, mk_and srk constr_conjs
+      | _ -> [], hypo
+    in
+    let mk_eq_by_typ typ ind1 ind2 = 
+      let var1 = mk_var srk ind1 typ in
+      let var2 = mk_var srk ind2 typ in
+      match typ with
+      | `TyBool -> mk_iff srk var1 var2
+      | `TyReal
+      | `TyInt -> mk_eq srk var1 var2
+      | `TyArr -> mk_arr_eq srk var1 var2
+    in 
+    (* This handles all of the logic for taking in the srk style propositions
+     * and deriving the chc style propositions. We return a tuple containing
+     * 1) a map from the original fvs to the news fvs
+     * 2) the chc style props (func symbol + names of params)
+     * 3) formulae that need to be added to the constraint as a result of the
+     * conversion from srk style props to chc style props*)
+    let parse_props props qpf =
+      let fv_order = Hashtbl.create 97 in
+      let cnter = ref (-1) in
+      let phis = ref [] in
+      List.map (fun (symbol, args) ->
+          {symbol;
+           names = 
+             List.mapi (fun ind_arg arg ->
+                 cnter := !cnter + 1;
+                 match destruct srk arg with
+                 | `Real q -> 
+                   let typ, typ_fun =
+                     match typ_symbol srk symbol with
+                     | `TyFun (lst, _) ->
+                       if List.nth lst ind_arg = `TyInt 
+                       then `TyInt, fun s -> QQ.to_zz s |> Option.get |> mk_zz srk
+                       else `TyReal, mk_real srk
+                     | _ -> assert false
+                   in
+                   phis := mk_eq srk (typ_fun q) (mk_var srk !cnter typ) :: !phis;
+                   "k"
+                 | `Tru ->
+                   phis := (mk_var srk !cnter `TyBool) :: !phis;
+                   "b"
+                 | `Fls ->
+                   phis := mk_not srk (mk_var srk !cnter `TyBool) :: !phis;
+                   "b"
+                 | `Var (i, typ) ->
+                   if Hashtbl.mem fv_order i then (
+                     let i2 = Hashtbl.find fv_order i in
+                     phis := mk_eq_by_typ (typ :> typ_fo) !cnter i2 :: !phis)
+                   else (Hashtbl.add fv_order i !cnter);
+                   fst (List.nth qpf i)
+                 | `Proposition (`Var i) ->
+                   if Hashtbl.mem fv_order i then (
+                     let i2 = Hashtbl.find fv_order i in
+                     phis := mk_eq_by_typ `TyBool !cnter i2 :: !phis)
+                   else (Hashtbl.add fv_order i !cnter);
+                   fst (List.nth qpf i)
+                 | _ -> assert false)
+               args})
+        props,
+      fv_order,
+      !phis
+    in
+    let non_prop_fvs constr prop_fv_map (qpf : (string * typ_fo) list) =
+      let fv_map = Hashtbl.create 97 in
+      BatHashtbl.fold (fun ind _ (counter, qinfos) ->
+          if Hashtbl.mem prop_fv_map ind then (counter, qinfos)
+          else (
+            Hashtbl.add fv_map ind counter;
+            (counter + 1, List.nth qpf ind :: qinfos)))
+        (free_vars constr)
+        (0, []),
+      fv_map
+    in
     let parse_rule rule =
-      let quanted, matrix =
-        if Z3.AST.is_quantifier (Z3.Expr.ast_of_expr rule) then
-          let q = Z3.Quantifier.quantifier_of_expr rule in
-          List.combine 
-            (List.rev (Z3.Quantifier.get_bound_variable_sorts q))
-            (List.rev (Z3.Quantifier.get_bound_variable_names q)),
-          Z3.Quantifier.get_body q
-        else [], rule
+      let rule = formula_of_z3 srk ~sym_of_decl rule in
+      let qnf_rule = Formula.prenex srk rule in
+      let qpf_rev, matrix = detach_qpf qnf_rule in
+      let qpf = List.rev qpf_rev in
+      let hypo, conc_prop = detach_conc matrix in
+      let hypo_props, constr = detach_hypo_props hypo in
+      let props, prop_fvs, phis = parse_props (conc_prop :: hypo_props) qpf in
+      (* The constr cannot have any free vars other than those used as an
+       * argument to a proposition. For the remaining fvs, we will bound them
+       * with quantifiers in the constraint. This requires reordering the fvs
+       * so that the non-prop fvs are the smaller debruijn indices. 
+       * These next few lines of code handles that. *)
+      let (num, qinfos), non_prop_fv_map = non_prop_fvs constr prop_fvs qpf in
+      let constr =
+        substitute
+          srk
+          (fun (ind, typ) ->
+             if Hashtbl.mem prop_fvs ind then
+               mk_var srk (num + (Hashtbl.find prop_fvs ind)) typ
+             else mk_var srk (Hashtbl.find non_prop_fv_map ind) typ)
+          constr
       in
-      let ind_to_sym = BatHashtbl.create 91 in
-      BatList.iteri (fun ind (sort, name) ->
-          let sym = 
-            mk_symbol srk ~name:(Z3.Symbol.to_string name) (typ_of_sort sort)
-          in
-          BatHashtbl.add ind_to_sym ind sym) 
-        quanted;
-      let decl =  decl_kind matrix in
-      let args = Z3.Expr.get_args matrix in
-      begin match decl, args with
-        | (OP_IMPLIES, [hypo;conc]) ->
-          let hypo_decl = decl_kind hypo in
-          let (atoms, eqs_args, z3phis) = 
-            begin match hypo_decl with
-              | OP_AND ->
-                let (rels, z3phis) = 
-                  List.partition 
-                    (fun arg -> 
-                       Z3.AST.get_ast_kind (Z3.Expr.ast_of_expr arg) = APP_AST
-                       && decl_kind arg = OP_UNINTERPRETED)
-                    (Z3.Expr.get_args hypo) 
-                in
-                let rel_atoms, eqs = 
-                  List.split 
-                    (List.map 
-                       (rel_atom_of_z3 srk fp ind_to_sym rsym_to_int)
-                       rels)
-                in
-               rel_atoms, List.flatten eqs, z3phis
-              | OP_UNINTERPRETED -> 
-                let atom, eqs = 
-                  rel_atom_of_z3 srk fp ind_to_sym rsym_to_int hypo 
-                in
-                [atom], eqs, []
-              | _ -> [], [], [hypo] 
-            end
-          in
-          let conc, eqs_args_conc = 
-            rel_atom_of_z3 srk fp ind_to_sym rsym_to_int conc 
-          in
-          let phi = mk_and srk (List.map (SrkZ3.formula_of_z3 srk) z3phis) in
-          let phi = 
-            substitute 
-              srk 
-              (fun (i, _) -> mk_const srk (BatHashtbl.find ind_to_sym i)) 
-              phi 
-          in 
-          let phi = mk_and srk (phi :: eqs_args @ eqs_args_conc) in
-          atoms, phi, conc
-        | (OP_UNINTERPRETED, _) ->
-          let conc, eqs = 
-            rel_atom_of_z3 srk fp ind_to_sym rsym_to_int matrix 
-          in
-          [], mk_and srk eqs, conc
-        | _ -> failwith "Rule not well formed"
-      end
+      let constr = mk_and srk (constr :: phis) in
+      let constr =
+        BatList.fold_left (fun constr (name, typ) ->
+            mk_exists srk ~name typ constr)
+          constr
+          (List.rev qinfos)
+      in
+      List.hd props, List.tl props, constr
     in
-    let parse_query query =
-      Hashtbl.find 
-        rsym_to_int
-        (Z3.Symbol.to_string 
-           (Z3.FuncDecl.get_name (Z3.Expr.get_func_decl query)))
-    in
+    let parse_query query = sym_of_decl (Z3.Expr.get_func_decl query) in
     let rules = List.map parse_rule (Z3.Fixedpoint.get_rules z3fp) in
-    let queries = List.map parse_query z3queries in
-    {rules; queries;rel_ctx=fp.rel_ctx}
+    let queries = Symbol.Set.of_list (List.map parse_query z3queries) in
+    {rules; queries}
 
-  let parse_file ?(ctx=Z3.mk_context []) srk fp filename =
+  let parse_file ?(ctx=Z3.mk_context []) srk filename =
     let z3 = ctx in
     let z3fp = Z3.Fixedpoint.mk_fixedpoint z3 in
     let z3queries = Z3.Fixedpoint.parse_file z3fp filename in
-    parse_z3fp ~z3queries srk fp z3fp
+    parse_z3fp ~z3queries srk z3fp
 
-  let parse_string ?(ctx=Z3.mk_context []) srk fp str =
+  let parse_string ?(ctx=Z3.mk_context []) srk str =
     let z3 = ctx in
     let z3fp = Z3.Fixedpoint.mk_fixedpoint z3 in
     let z3queries = Z3.Fixedpoint.parse_string z3fp str in
-    parse_z3fp ~z3queries srk fp z3fp
+    parse_z3fp ~z3queries srk z3fp
 end

--- a/srk/src/chc.ml
+++ b/srk/src/chc.ml
@@ -2,12 +2,15 @@
 open Syntax
 open BatPervasives
 module DynArray = BatDynArray
+module D = Graph.Pack.Digraph
+module WG = WeightedGraph
 
 type relation = int
 type rel_atom = relation * symbol list
-type 'a fp = {mutable rules : (rel_atom list * 'a formula * rel_atom) list; 
-              mutable queries : relation list;
-              rel_ctx : (string * typ list) DynArray.t} 
+type 'a fp = { mutable rules : (rel_atom list * 'a formula * rel_atom) list; 
+               mutable queries : relation list;
+               rel_ctx : (string * typ_fo list) DynArray.t } 
+
 
 let mk_relation fp ?(name="R") typ =
   DynArray.add fp.rel_ctx (name, typ);
@@ -18,11 +21,18 @@ let name_of fp rel = fst (DynArray.get fp.rel_ctx rel)
 let rel_of_atom (relation, _) = relation
 let params_of_atom (_, params) = params
 
-let mk_rel_atom srk fp rel syms =
-  if ((type_of fp rel) = (List.map (typ_symbol srk) syms))
-  then rel, syms
-  else failwith "Types Error Rel Atom"
+let typ_symbol_fo srk sym =
+  match typ_symbol srk sym with
+  | `TyInt -> `TyInt
+  | `TyReal -> `TyReal
+  | `TyBool -> `TyBool
+  (* TODO: arrays *)
+  | _ -> assert false
 
+let mk_rel_atom srk fp rel syms =
+  if ((type_of fp rel) = (List.map (typ_symbol_fo srk) syms))
+  then rel, syms
+  else invalid_arg "Type Error mk_rel_atom"
 
 module Relation = struct
   type t = relation 
@@ -77,7 +87,7 @@ module Fp = struct
 
   let add_query fp query = fp.queries <- query :: fp.queries 
 
-  let get_relations_used fp =
+  let get_active_relations fp =
     List.fold_left
       (fun rset (hypo_atoms, _, conc_atom) ->
          List.fold_left
@@ -91,27 +101,73 @@ module Fp = struct
       fp.rules
 
   let get_relations_declared fp =
-    BatList.of_enum (0 -- ((DynArray.length fp.rel_ctx) - 1)) 
+    BatList.of_enum (0 -- ((DynArray.length fp.rel_ctx) - 1))
 
-  let is_linear fp =
+  let is_linear rules =
     BatList.fold_left 
       (fun acc (hypo_atoms, _, _) -> acc && (List.length hypo_atoms) <= 1)
       true
-      fp.rules
+      rules
+
+  let mk_eq_by_sort srk s1 s2 =
+    assert (typ_symbol srk s1 = typ_symbol srk s2);
+    match typ_symbol_fo srk s1 with
+    | `TyInt | `TyReal -> mk_eq srk (mk_const srk s1) (mk_const srk s2)
+    | `TyBool -> mk_iff srk (mk_const srk s1) (mk_const srk s2)
+
+  let normalize srk fp =
+    let rules' =
+      List.map (fun (hypos, constr, conc) ->
+          let update_atom (atom, eqs, syms) =
+            let params, eqs, syms =
+              List.fold_right
+                (fun param (params, eqs, syms) ->
+                   if not (Symbol.Set.mem param syms) then
+                     param :: params, eqs, (Symbol.Set.add param syms)
+                   else
+                     let s = dup_symbol srk param in
+                     let eq = mk_eq_by_sort srk s param in
+                     s :: params, eq :: eqs, Symbol.Set.add s syms)
+                (params_of_atom atom) 
+                ([], eqs, syms)
+            in
+            let atom' = mk_rel_atom srk fp (rel_of_atom atom) params in
+            atom', eqs, syms
+          in
+          let (hypos', eqs, syms) =
+            List.fold_left 
+              (fun (hypos', eqs, syms) hypo ->
+                 let atom', eqs', syms' = update_atom (hypo, eqs, syms) in
+                 atom' :: hypos', eqs', syms')
+              ([], [],  Symbol.Set.empty)
+              hypos
+          in
+          let (conc', eqs, syms) = update_atom (conc, eqs, syms) in
+          let constr' = 
+            mk_exists_consts 
+              srk 
+              (fun s -> Symbol.Set.mem s syms) 
+              (mk_and srk (constr :: eqs))
+          in
+          hypos', constr', conc')
+        fp.rules
+    in
+    {rules=rules'; queries=fp.queries; rel_ctx=fp.rel_ctx} 
+
 
   let goal_vert = -2 
-  let start_vert = -1 
-  let to_weighted_graph srk fp pd =
+  let start_vert = -1
+  let emptyarr = BatArray.init 0 (fun _ -> failwith "empty")
+
+  let linchc_to_weighted_graph srk fp pd =
+    let fp = normalize srk fp in
     let open WeightedGraph in
-    let emptyarr = BatArray.init 0 (fun _ -> failwith "empty") in
+    (* The edges of the graph are of the form [(syms', syms', constr)] where 
+     * [syms] are the var symbols used in the hypothesis relation, [syms'] are
+     * those used in the conclusion relation, and [constr] in the constraint
+     * whose free variables are limited to [syms union syms']. Further, [syms]
+     * and [syms'] are always disjoint. *)
     let alg = 
-      let map_union m1 m2 = Symbol.Map.fold Symbol.Map.add m1 m2 in
-      let mk_subst_map a b =
-        BatArray.fold_lefti 
-          (fun map ind asym -> Symbol.Map.add asym (mk_const srk (b.(ind))) map)
-          Symbol.Map.empty
-          a
-      in
       let is_one (_, _, phi) = Formula.equal phi (mk_true srk) in
       let is_zero (_, _, phi) = Formula.equal phi (mk_false srk) in
       let zero = emptyarr, emptyarr, mk_false srk in
@@ -120,120 +176,312 @@ module Fp = struct
         if is_zero x then y else if is_zero y then x
         else if is_one x || is_one y then one
         else (
-          let (pre, post, _) = x in
-          let pre' = Array.map (fun sym -> dup_symbol srk sym) pre in
-          let post' = Array.map (fun sym -> dup_symbol srk sym) post in
-          let subst (pre, post, phi) = 
-            substitute_map
-              srk 
-              (map_union (mk_subst_map pre pre') (mk_subst_map post post'))
-              phi
+          let (prex, postx, phix) = x in
+          let (prey, posty, phiy) = y in
+          let rhs_new = 
+            substitute_sym 
+              srk
+              (fun sym ->
+                 try mk_const srk (prex.(BatArray.findi ((=) sym) prey))
+                 with Not_found -> 
+                   mk_const srk (postx.(BatArray.findi ((=) sym) posty)))
+              phiy
           in
-          pre', post', mk_or srk [subst x; subst y])
+          prex, postx, mk_or srk [phix; rhs_new])
       in
-      let mul x y = 
+      let mul x y =
+        let (prex, postx, phix) = x in
+        let (prey, posty, phiy) = y in
         if is_zero x || is_zero y then zero
         else if is_one x then y else if is_one y then x
         else (
-          let (pre1, post1, phi1) = x in
-          let (pre2, post2, phi2) = y in
-          let pre' = Array.map (fun sym -> dup_symbol srk sym) pre1 in
-          let post' = Array.map (fun sym -> dup_symbol srk sym) post2 in 
-          let rhs_pre_postmap = 
-            map_union (mk_subst_map post2 post') (mk_subst_map pre2 post1)
+          let pre' = Array.map (dup_symbol srk) prex in
+          let post' = Array.map (dup_symbol srk) posty in
+          let lhs_subst =
+            (fun sym ->
+               try mk_const srk (pre'.(BatArray.findi ((=) sym) prex))
+               with Not_found -> mk_const srk sym)
           in
-          let rhs_subst =
-            Memo.memo 
-              ~size:(2 * (Symbol.Set.cardinal (symbols phi2)))
-              (fun sym -> 
-                 if Symbol.Map.mem sym rhs_pre_postmap then
-                   Symbol.Map.find sym rhs_pre_postmap
-                 else (mk_const srk (dup_symbol srk sym)))
+          let rhs_subst = (fun sym ->
+              try mk_const srk (postx.(BatArray.findi ((=) sym) prey))
+              with Not_found -> 
+                mk_const srk (post'.(BatArray.findi ((=) sym) posty)))
           in
-          let phi2 = substitute_const srk rhs_subst phi2 in
-          let phi1 = substitute_map srk (mk_subst_map pre1 pre') phi1 in
-          pre', post', mk_and srk [phi1; phi2]
-        )
+          let phiy' = substitute_sym srk rhs_subst phiy in
+          let phix' = substitute_sym srk lhs_subst phix in
+          let phi' = 
+            mk_exists_consts 
+              srk 
+              (fun s -> not (Array.mem s postx)) 
+              (mk_and srk [phix'; phiy']) 
+          in
+          (* TODO: try to remove the new quants via miniscoping/del procedure *)
+          pre', post', phi')
       in
       let star (pre, post, phi) =
         let module PD = (val pd : Iteration.PreDomain) in
-        let trs =
+        let (trs, vars) =
           BatArray.fold_lefti
-            (fun trs ind presym -> (presym, post.(ind)) :: trs)
-            []
+            (fun (trs, vars) ind presym -> 
+               (presym, post.(ind)) :: trs, presym :: post.(ind) :: vars)
+            ([], [])
             pre
         in
         let lc = mk_symbol srk `TyInt in
-        let tr_phi = TransitionFormula.make phi trs in
-        pre, post, 
-        PD.exp srk trs (mk_const srk lc) (PD.abstract srk tr_phi)
+        let tf = TransitionFormula.make phi trs in
+        let phi' = PD.exp srk trs (mk_const srk lc) (PD.abstract srk tf) in
+        let phi' = mk_exists_consts srk (fun s -> List.mem s vars) phi' in
+        (* TODO: try to remove the new quants via miniscoping/del procedure *)
+        pre, post, phi' 
       in
       {mul; add; star; zero; one}
     in
     let wg = WeightedGraph.add_vertex (WeightedGraph.empty alg) start_vert in
     let wg = WeightedGraph.add_vertex wg goal_vert in
-    let wg = Relation.Set.fold 
-        (fun rel_sym wg -> WeightedGraph.add_vertex wg rel_sym)
-        (get_relations_used fp)
+    let wg = 
+      List.fold_left 
+        (fun wg rel_sym -> WeightedGraph.add_vertex wg rel_sym)
         wg
+        (get_relations_declared fp)
     in
     let wg = 
       List.fold_left
         (fun wg (rel_atoms, phi, conc) ->
            match rel_atoms with
-           | [] -> WeightedGraph.add_edge 
-                     wg 
-                     start_vert
-                     (emptyarr, BatArray.of_list (params_of_atom conc), phi)
-                     (rel_of_atom conc)
-           | [hd] ->
+           | [] -> 
              WeightedGraph.add_edge 
                wg 
+               start_vert
+               (emptyarr, BatArray.of_list (params_of_atom conc), phi)
+               (rel_of_atom conc)
+           | [hd] -> 
+             WeightedGraph.add_edge 
+               wg
                (rel_of_atom hd)
                (BatArray.of_list (params_of_atom hd), 
                 BatArray.of_list (params_of_atom conc), 
                 phi)
                (rel_of_atom conc)
-           | _ -> failwith "Rule with multiple relations in hypothesis")
+           | _ -> failwith "CHC is non-linear")
         wg
         fp.rules
     in
     let wg =
       List.fold_left
-        (fun wg rel -> 
-           WeightedGraph.add_edge
-             wg
-             rel
-             alg.one
-             goal_vert)
+        (fun wg rel -> WeightedGraph.add_edge wg rel alg.one goal_vert)
         wg
         fp.queries
     in
     wg
 
-  let check srk fp pd = 
-    if is_linear fp then (
-      let wg = to_weighted_graph srk fp pd in
-      let _, _, phi = WeightedGraph.path_weight wg start_vert goal_vert in
-      begin match Smt.is_sat srk phi with
-        | `Unsat -> `No
-        | `Unknown -> `Unknown
-        | `Sat -> `Unknown
-      end)
-    else failwith "No methods for solving non lin fp"
+  let is_super_linear fp =
+    (* Initialize graph: One vertex for each rel symbol.
+     * There is an edge from rel a to rel b if a occurs in the
+     * hypothesis of some rule for which b occurs in the conclusion.
+     * A topological sort on the sccs of this graph will determine the
+     * ordering on which we need to solve the relations.*)
+    let num_rels = (DynArray.length fp.rel_ctx) - 1 in
+    let verts = BatArray.init (num_rels + 1) D.V.create in
+    let graph = D.create () in
+    BatArray.iter (fun v -> D.add_vertex graph v) verts;
+    BatList.iter (fun (hypo_atoms, _, conc_atom) ->
+        List.iter (fun hatom ->
+            D.add_edge 
+              graph 
+              (verts.(rel_of_atom hatom)) 
+              (verts.(rel_of_atom conc_atom)))
+          hypo_atoms)
+      fp.rules;
+    (* We create a new graph in which each scc is collapsed to
+     * a single node and there is an edge from scc a to scc b
+     * iff scc b was reachable from scc a in the original graph*)
+    let sccs = D.Components.scc_array graph in
+    let scc_rep = Array.map (fun scc ->  List.hd scc) sccs in
+    let path_check = D.PathCheck.create graph in
+    let sccverts = BatArray.init (Array.length sccs) D.V.create in
+    let sccgraph = D.create () in
+    BatArray.iter (fun v -> D.add_vertex sccgraph v) sccverts;
+    BatArray.iteri (fun scc1 rel1 ->
+        BatArray.iteri (fun scc2 rel2 ->
+            if D.PathCheck.check_path path_check rel1 rel2 then
+              D.add_edge sccgraph (sccverts.(scc1)) (sccverts.(scc2))
+            else ())
+          scc_rep)
+      scc_rep;
+    let solved = Hashtbl.create (num_rels + 1) in
+    (* We compute a topologoical sort on the collapsed graph determine
+     * if the collapsed graph forms a stratified lin system of chcs.*)
+    let (ordering, is_strat) = 
+      D.Topological.fold (fun scc_num (ordering, is_stratifiable) ->
+          (* First we extract the sub-chc *)
+          let of_vert arr v = BatArray.findi ((=) v) arr in
+          let rels = 
+            Relation.Set.of_list 
+              (List.map (of_vert verts) sccs.(of_vert sccverts scc_num)) 
+          in
+          let ordering' = rels :: ordering in
+          let ruleset = 
+            List.filter (fun (_, _, conc_atom) ->
+                Relation.Set.mem (rel_of_atom conc_atom) rels)
+              fp.rules
+          in
+          let is_stratifiable' = List.fold_left (fun acc (hypo_atoms, _, _) ->
+              if List.length (List.filter (fun atom ->
+                  not (Hashtbl.mem solved (rel_of_atom atom)))
+                  hypo_atoms) > 1
+              then false
+              else true && acc)
+              is_stratifiable
+              ruleset
+          in
+          Relation.Set.iter 
+            (fun rel -> Hashtbl.add solved rel ()) 
+            rels;
+          (ordering', is_stratifiable')
+        )
+        sccgraph
+        ([], true)
+    in
+    if is_strat then Some (List.rev ordering) else None
+
+
+  let solve_super_lin srk fp pd ordering =
+    let fp = normalize srk fp in
+    let num_rels = (DynArray.length fp.rel_ctx) - 1 in
+    let solution = Hashtbl.create (num_rels + 1) in
+    (* We compute a topologoical sort on the collapsed graph and solve
+     * for the relations in order.*)
+    List.iter (fun rels ->
+        let ruleset = 
+          List.filter (fun (_, _, conc_atom) ->
+              Relation.Set.mem (rel_of_atom conc_atom) rels)
+            fp.rules
+        in
+        (* Substitute in the solutions for rels calculated at previous strata *)
+        let ruleset' = List.map (fun (hypo_atoms, constr, conc) ->
+            let hypo_atoms', constr' = 
+              List.fold_left (fun (hypo_atoms, constr) atom -> 
+                  if Hashtbl.mem solution (rel_of_atom atom) then (
+                    let syms, soln = Hashtbl.find solution (rel_of_atom atom) in
+                    let subst =
+                      (fun sym ->
+                         mk_const
+                           srk
+                           (List.nth
+                              (params_of_atom atom)
+                              (BatArray.findi ((=) sym) syms)))
+                    in
+                    let soln = substitute_const srk subst soln in
+                    hypo_atoms, mk_and srk [soln; constr])
+                  else (atom :: hypo_atoms, constr))
+                ([], constr)
+                hypo_atoms
+            in
+            hypo_atoms', constr', conc)
+            ruleset
+        in
+        if is_linear ruleset' then (
+          let sub_fp = {rules=ruleset'; queries=[]; rel_ctx=fp.rel_ctx} in
+          let wg = linchc_to_weighted_graph srk sub_fp pd in
+          let sub_soln = 
+            (fun rel -> 
+               let _, params, phi = WG.path_weight wg start_vert rel in 
+               params, phi) 
+          in
+          Relation.Set.iter 
+            (fun rel -> Hashtbl.add solution rel (sub_soln rel)) 
+            rels)
+        else (invalid_arg "Chc not super-linear"))
+      ordering;
+    let goal = 
+      mk_or 
+        srk 
+        (List.map (fun rel -> snd (Hashtbl.find solution rel)) fp.queries) 
+    in
+    Hashtbl.add solution goal_vert (emptyarr, goal);  
+    Hashtbl.find solution
+
+
+  let query_vc_condition srk fp pd =
+    match is_super_linear fp with
+    | None -> failwith "No methods for solving non super linear chc systems"
+    | Some ordering ->
+      let res = solve_super_lin srk fp pd ordering in
+      let _, phi = res goal_vert in   
+      phi
+
+  let check srk fp pd =
+    let phi = query_vc_condition srk fp pd in
+    match Quantifier.simsat srk phi with
+      | `Unsat  -> `No
+      | `Unknown -> `Unknown
+      | `Sat -> `Unknown
 
   let solve srk fp pd =
-    if is_linear fp then (
-      let wg = to_weighted_graph srk fp pd in
-      let soln = 
-        (fun rel -> 
-           let _, params, phi = WeightedGraph.path_weight wg start_vert rel in 
-           params, phi) 
-      in
-      soln)
-    else failwith "No methods for solving non lin fp"
+    match is_super_linear fp with
+    | None -> failwith "No methods for solving non lin fp"
+    | Some ordering -> solve_super_lin srk fp pd ordering
 
-
+  let unbooleanize srk fp =
+    let fp' = create () in
+    let rel_map = BatHashtbl.create (List.length (get_relations_declared fp)) in
+    List.iter (fun rel ->
+        let typ' = 
+          List.map (fun typ -> 
+              if typ = `TyBool then `TyInt else typ) 
+            (type_of fp rel)
+        in
+        let rel' = mk_relation fp' ~name:(name_of fp rel) typ' in
+        BatHashtbl.add rel_map rel rel')
+      (get_relations_declared fp);
+    List.iter (fun (hypos, phi, conc) ->
+        let sym_map = BatHashtbl.create 97 in
+        let map_atom atom =
+          let params' = 
+            List.map (fun param ->
+                if typ_symbol srk param = `TyBool then (
+                  if BatHashtbl.mem sym_map param then
+                    BatHashtbl.find sym_map param
+                  else
+                    let param' = mk_symbol srk ~name:(show_symbol srk param) `TyInt in
+                    BatHashtbl.add sym_map param param';
+                    param')
+                else
+                  param)
+              (params_of_atom atom)
+          in
+          let rel' = BatHashtbl.find rel_map (rel_of_atom atom) in
+          mk_rel_atom srk fp' rel' params'
+        in
+        let hypos' = List.map map_atom hypos in
+        let conc' = map_atom conc in
+        let phi_subst = 
+          substitute_const 
+            srk
+            (fun s -> 
+               if BatHashtbl.mem sym_map s then
+                 mk_eq srk (mk_one srk) (mk_const srk (BatHashtbl.find sym_map s))
+               else
+                 mk_const srk s)
+            phi
+        in
+        let bool_constrs =
+          BatHashtbl.fold (fun _ sym acc -> 
+              mk_or 
+                srk 
+                [mk_eq srk (mk_const srk sym) (mk_one srk);
+                 mk_eq srk (mk_const srk sym) (mk_zero srk)] :: acc)
+            sym_map
+            []
+        in
+        let phi' = mk_and srk (phi_subst :: bool_constrs) in
+        add_rule fp' hypos' phi' conc')
+      fp.rules;
+    List.iter (fun rel -> 
+        add_query fp' (BatHashtbl.find rel_map rel)) 
+      fp.queries;
+    let rel_fun rel = BatHashtbl.find rel_map rel in
+    rel_fun, fp'
 end
 
 module ChcSrkZ3 = struct
@@ -244,120 +492,119 @@ module ChcSrkZ3 = struct
     | REAL_SORT -> `TyReal
     | INT_SORT -> `TyInt
     | BOOL_SORT -> `TyBool
-    | _ -> failwith "TODO: allow function types"
+    (*| ARRAY_SORT -> `TyArr*)
+    |_ -> failwith "function types not currently supported in rel param"
 
-  (* Creates a relation atom from a z3 predicate in which each argument
-   * to the predicate is an integer. Replaces integer [i] with value
-   * located at key [i] in table [ind_to_sym] when such a key exists *)
-  let rel_atom_of_z3 srk fp ind_to_sym rsym_to_int names z3pred =
+  let rel_atom_of_z3 srk fp ind_to_sym rsym_to_int z3pred =
+    let eqs = ref [] in
     let args = List.map 
-        (fun arg -> 
-           let index = Z3.Quantifier.get_index arg in
-           if BatHashtbl.mem ind_to_sym index then
-             BatHashtbl.find ind_to_sym index
-           else (
-             let sort = typ_of_sort (Z3.Expr.get_sort arg) in
-             let sym = 
-               mk_symbol srk ~name:(Z3.Symbol.to_string names.(index)) sort 
-             in
-             BatHashtbl.add ind_to_sym index sym;
-             sym)) 
+        (fun arg ->
+           begin match Z3.AST.get_ast_kind (Z3.Expr.ast_of_expr arg) with
+             | VAR_AST ->
+               let index = Z3.Quantifier.get_index arg in
+               BatHashtbl.find ind_to_sym index
+               (* Logic for handling case if rel atom arg is a numerical
+                * or logical constant *)
+             | NUMERAL_AST ->
+               let sym = mk_symbol srk `TyInt in
+               let q = SrkZ3.term_of_z3 srk arg in
+               eqs := (mk_eq srk (mk_const srk sym) q) :: !eqs;
+               sym
+             | APP_AST -> 
+               let decl = Z3.Expr.get_func_decl arg in
+               begin match Z3.FuncDecl.get_decl_kind decl with
+               | OP_TRUE ->
+                 let sym = mk_symbol srk `TyBool in
+                 eqs := (mk_const srk sym) :: !eqs;
+                 sym
+               | OP_FALSE -> 
+                 let sym = mk_symbol srk `TyBool in
+                 eqs := (mk_not srk (mk_const srk sym)) :: !eqs;
+                 sym
+               | _ -> invalid_arg "Cannot have non-trivial terms as param to relation"
+               end
+             | _ -> assert false
+           end) 
         (Z3.Expr.get_args z3pred) in
     let decl = Z3.Expr.get_func_decl z3pred in
     let rsym = Z3.Symbol.to_string (Z3.FuncDecl.get_name decl) in
     let relation = 
       if Hashtbl.mem rsym_to_int rsym then Hashtbl.find rsym_to_int rsym
       else (
-        let typ = List.map (fun arg -> typ_symbol srk arg) args in
+        let typ = List.map (fun arg -> typ_symbol_fo srk arg) args in
         let res = mk_relation fp ~name:rsym typ in
         Hashtbl.add rsym_to_int rsym res;
         res)
     in
-    relation, args
-
-  (* Similiar to above but always uses creates a fresh symbol. [eq_syms] tracks
-   * which fresh symbols we created for indices that already exist in 
-   * [ind_to_sym] *)
-  let rel_atom_of_z3_fresh srk fp ind_to_sym rsym_to_int names z3pred =
-    let fresh_index_map = BatHashtbl.create 91 in
-    let eq_syms = ref [] in
-    let atom = 
-      rel_atom_of_z3 srk fp fresh_index_map rsym_to_int names z3pred 
-    in
-    BatHashtbl.iter (fun ind sym ->
-        if BatHashtbl.mem ind_to_sym ind 
-        then eq_syms := ((BatHashtbl.find ind_to_sym ind), sym) :: !eq_syms
-        else BatHashtbl.add ind_to_sym ind sym)
-      fresh_index_map;
-    atom, !eq_syms
-
+    (relation, args), !eqs
 
   let parse_z3fp ?(z3queries=[]) srk fp z3fp =
     let rsym_to_int = BatHashtbl.create 91 in
     let decl_kind e = Z3.FuncDecl.get_decl_kind (Z3.Expr.get_func_decl e) in
     let parse_rule rule =
-      let names, matrix =
+      let quanted, matrix =
         if Z3.AST.is_quantifier (Z3.Expr.ast_of_expr rule) then
           let q = Z3.Quantifier.quantifier_of_expr rule in
-          BatArray.of_list (Z3.Quantifier.get_bound_variable_names q), 
+          List.combine 
+            (List.rev (Z3.Quantifier.get_bound_variable_sorts q))
+            (List.rev (Z3.Quantifier.get_bound_variable_names q)),
           Z3.Quantifier.get_body q
-        else BatArray.init 0 (fun _ -> failwith "empty array"), rule
+        else [], rule
       in
+      let ind_to_sym = BatHashtbl.create 91 in
+      BatList.iteri (fun ind (sort, name) ->
+          let sym = 
+            mk_symbol srk ~name:(Z3.Symbol.to_string name) (typ_of_sort sort)
+          in
+          BatHashtbl.add ind_to_sym ind sym) 
+        quanted;
       let decl =  decl_kind matrix in
       let args = Z3.Expr.get_args matrix in
       begin match decl, args with
         | (OP_IMPLIES, [hypo;conc]) ->
-          let ind_to_sym = BatHashtbl.create 91 in
           let hypo_decl = decl_kind hypo in
-          let (atoms, phi) = 
+          let (atoms, eqs_args, z3phis) = 
             begin match hypo_decl with
               | OP_AND ->
-                let (rels, phis) = 
+                let (rels, z3phis) = 
                   List.partition 
-                    (fun arg -> decl_kind arg = OP_UNINTERPRETED)
+                    (fun arg -> 
+                       Z3.AST.get_ast_kind (Z3.Expr.ast_of_expr arg) = APP_AST
+                       && decl_kind arg = OP_UNINTERPRETED)
                     (Z3.Expr.get_args hypo) 
                 in
-                let rel_atoms = 
-                  List.map 
-                    (rel_atom_of_z3 srk fp ind_to_sym rsym_to_int names)
-                    rels
+                let rel_atoms, eqs = 
+                  List.split 
+                    (List.map 
+                       (rel_atom_of_z3 srk fp ind_to_sym rsym_to_int)
+                       rels)
                 in
-                let phis = List.map (SrkZ3.formula_of_z3 srk) phis in
-                rel_atoms, (mk_and srk phis)
+               rel_atoms, List.flatten eqs, z3phis
               | OP_UNINTERPRETED -> 
-                [rel_atom_of_z3 srk fp ind_to_sym rsym_to_int names hypo],
-                mk_true srk
-              (* Potentially need add special handling for "OR" case similar to
-               * "AND" case *)
-              | _ -> [], SrkZ3.formula_of_z3 srk hypo
+                let atom, eqs = 
+                  rel_atom_of_z3 srk fp ind_to_sym rsym_to_int hypo 
+                in
+                [atom], eqs, []
+              | _ -> [], [], [hypo] 
             end
           in
-          let conc, eq_syms = 
-            rel_atom_of_z3_fresh srk fp ind_to_sym rsym_to_int names conc 
+          let conc, eqs_args_conc = 
+            rel_atom_of_z3 srk fp ind_to_sym rsym_to_int conc 
           in
-          let phi = mk_and 
+          let phi = mk_and srk (List.map (SrkZ3.formula_of_z3 srk) z3phis) in
+          let phi = 
+            substitute 
               srk 
-              ((substitute 
-                  srk 
-                  (fun (ind,_) -> 
-                     if BatHashtbl.mem ind_to_sym ind 
-                     then mk_const srk (BatHashtbl.find ind_to_sym ind)
-                     else failwith "Free var in rule formula not bound in rel")
-                  phi)
-               :: (List.map (fun (s, t) -> 
-                   mk_eq 
-                     srk 
-                     (mk_const srk s) 
-                     (mk_const srk t))
-                   eq_syms))
-          in
+              (fun (i, _) -> mk_const srk (BatHashtbl.find ind_to_sym i)) 
+              phi 
+          in 
+          let phi = mk_and srk (phi :: eqs_args @ eqs_args_conc) in
           atoms, phi, conc
         | (OP_UNINTERPRETED, _) ->
-          let ind_to_sym = BatHashtbl.create 91 in
-          let conc = 
-            rel_atom_of_z3 srk fp ind_to_sym rsym_to_int names matrix 
+          let conc, eqs = 
+            rel_atom_of_z3 srk fp ind_to_sym rsym_to_int matrix 
           in
-          [], mk_true srk, conc
+          [], mk_and srk eqs, conc
         | _ -> failwith "Rule not well formed"
       end
     in
@@ -382,6 +629,4 @@ module ChcSrkZ3 = struct
     let z3fp = Z3.Fixedpoint.mk_fixedpoint z3 in
     let z3queries = Z3.Fixedpoint.parse_string z3fp str in
     parse_z3fp ~z3queries srk fp z3fp
-
-
 end

--- a/srk/src/chc.mli
+++ b/srk/src/chc.mli
@@ -1,64 +1,28 @@
 (* Constrained horn clauses *)
 open Syntax
 
-type relation
-type rel_atom
-type 'a fp = {mutable rules : (rel_atom list * 'a formula * rel_atom) list; 
-              mutable queries : relation list;
-              rel_ctx : (string * typ_fo list) BatDynArray.t} 
+type proposition
+type 'a fp 
 
-val pp_rel_atom : 'a context -> 'a fp -> Format.formatter -> rel_atom -> unit
-val show_rel_atom : 'a context -> 'a fp -> rel_atom -> string
-
-(* Makes fresh relation symbol *)
-val mk_relation : 'a fp -> ?name:string -> typ_fo list -> relation
-val type_of : 'a fp -> relation -> typ_fo list
-val name_of : 'a fp -> relation -> string
-
-(** This function includes typechecking. We hide the type of relation atoms 
- * to force the use to have their atom type checked *)
-val mk_rel_atom : 'a context -> 'a fp -> relation -> symbol list -> rel_atom
-
-val rel_of_atom : rel_atom -> relation
-val params_of_atom : rel_atom -> symbol list
-
-module Relation : sig
-  type t = relation
-  module Set : BatSet.S with type elt = relation
-  val compare : t -> t -> int
-  val pp : 'a fp -> Format.formatter -> relation -> unit
-  val show : 'a fp -> relation -> string
+module Proposition : sig
+  type t = proposition
+  val symbol_of : t -> symbol
+  val names_of : t -> string list
+  val typ_of_params : 'a context -> t -> typ_fo list
+  val mk_proposition : 'a context -> symbol -> string list -> t
 end
 module Fp : sig
   type 'a t = 'a fp
   (** Create fixed point object with no rules/queries *)
-  val create : unit -> 'a fp
-  val add_rule : 'a fp -> rel_atom list -> 'a formula -> rel_atom -> unit
+  val empty : 'a fp
+  val add_rule : 'a fp -> proposition -> proposition list -> 'a formula -> 'a fp
   (** Adds query to fp and returns a fresh name for query *)
-  val add_query : 'a fp -> relation -> unit
+  val add_query : 'a fp -> symbol -> 'a fp
   (* Returns set of relations that occur in either a rule or query in fp *)
-  val get_active_relations : 'a fp -> Relation.Set.t
-  (* Returns list of all relations declared in fp context *)
-  val get_relations_declared : 'a fp -> relation list
+  (*val predicate_symbols : 'a fp -> Symbol.Set.t*)
   val pp : 'a context -> Format.formatter -> 'a fp -> unit
   val show : 'a context  -> 'a fp -> string
 
-  (* Limit each variable symbol to occur at most once as a parameter
-   * in any given rule.
-   *
-   * For example, the rule R1(x) -> R2(x) is turned into R1(x) /\ x = x' => R2(x')
-   *
-   * Additionally quantifies over free vars in a constraint to that do not
-   * appear as a parameter to a relation atom in the rule that constraint 
-   * belongs to (that is, skolem constants will be unskomelized).
-   *)
-  val normalize : 'a context -> 'a fp -> 'a fp
-  (* Creates an equivalent fp in which boolean parameters have been mapped to
-   * integer parameters. Where [map, fp' = unbooleanize srk fp], the relation
-   * [r] in [fp] is mapped to the relation symbol [map r] in [fp'].*)
-  val unbooleanize : 'a context -> 'a fp -> (relation -> relation) * 'a fp
-  (** [is_linear rules] returns true if rules defines linear system of chcs *)
-  val is_linear : (rel_atom list * 'a formula * rel_atom) list -> bool
   (** [check srk fp pd] returns unknown if a query relation can
    * be reached in the fp where recursion over-approximated using the 
    * star operator of the provided predomain [pd] and returns no otherwise.*)
@@ -77,13 +41,13 @@ module Fp : sig
    * [(syms, phi) = f r] where [phi] is a formula in which [syms.(i)]
    * gives the symbol used for the [i]th argument to [r].*)
   val solve : 'a context -> 'a fp -> (module Iteration.PreDomain) ->
-    (relation -> symbol array * 'a formula)
+    (int -> 'a formula)
 end
 
 module ChcSrkZ3 : sig
   (* Convert z3 fixedpoint into srk fixedpoint *)
-  val parse_z3fp : ?z3queries:Z3.Expr.expr list -> 'a context -> 'a fp -> 
+  val parse_z3fp : ?z3queries:Z3.Expr.expr list -> 'a context  -> 
     Z3.Fixedpoint.fixedpoint -> 'a fp
-  val parse_file : ?ctx:Z3.context -> 'a context -> 'a fp -> string -> 'a fp 
-  val parse_string : ?ctx:Z3.context -> 'a context -> 'a fp -> string -> 'a fp
+  val parse_file : ?ctx:Z3.context -> 'a context -> string -> 'a fp 
+  val parse_string : ?ctx:Z3.context -> 'a context -> string -> 'a fp
 end

--- a/srk/src/iteration.mli
+++ b/srk/src/iteration.mli
@@ -54,6 +54,10 @@ module LinearRecurrenceInequation : PreDomain
    term over y. *)
 module NonlinearRecurrenceInequation : PreDomainWedge
 
+(* Lifts a predomain over LIA formula to one over quantified lia formula
+ * by performing quantifier elimination prior to abstraction *)
+module QLIALift (Iter : PreDomain) : PreDomain
+
 (** Improve iteration operator using split invariants *)
 module Split(Iter : PreDomain) : PreDomain
 

--- a/srk/src/srkZ3.ml
+++ b/srk/src/srkZ3.ml
@@ -346,20 +346,26 @@ let of_z3 context sym_of_decl expr =
    Z3 int symbols *)
 let sym_of_decl decl =
   let sym = Z3.FuncDecl.get_name decl in
-  assert (Z3.Symbol.is_int_symbol sym);
-  symbol_of_int (Z3.Symbol.get_int sym)
+  match Z3.Symbol.kind sym with
+  | STRING_SYMBOL -> assert false
+   (* let name = Z3.Symbol.get_string sym in
+    if is_registered_name srk name
+    then get_named_symbol srk name
+    else register_named_symbol srk name; *)
+  | INT_SYMBOL -> symbol_of_int (Z3.Symbol.get_int sym)
 
-let term_of_z3 context term =
+let term_of_z3 context ?sym_of_decl:(sym_of_decl = sym_of_decl) term =
   match Expr.refine_coarse context (of_z3 context sym_of_decl term) with
   | `Term t -> t
   | _ -> invalid_arg "term_of"
 
-let formula_of_z3 context phi =
+let formula_of_z3 context ?sym_of_decl:(sym_of_decl = sym_of_decl) phi =
   match Expr.refine context (of_z3 context sym_of_decl phi) with
   | `Formula phi -> phi
   |  _ -> invalid_arg "formula_of"
 
-let expr_of_z3 context expr = of_z3 context sym_of_decl expr
+let expr_of_z3 context ?sym_of_decl:(sym_of_decl = sym_of_decl) expr = 
+  of_z3 context sym_of_decl expr
 
 type 'a solver =
   { srk : 'a context;

--- a/srk/src/srkZ3.mli
+++ b/srk/src/srkZ3.mli
@@ -33,15 +33,18 @@ val z3_of_expr : 'a context -> z3_context -> ('a,typ_fo) expr -> z3_expr
 
 (** Convert a Z3 expression into a term.  Raises [Invalid_argument] on
     failure. *)
-val term_of_z3 : 'a context -> z3_expr -> 'a term
+val term_of_z3 : 'a context -> ?sym_of_decl:(Z3.FuncDecl.func_decl -> symbol) -> 
+  z3_expr -> 'a term
 
 (** Convert a Z3 expression into a formula.  Raises [Invalid_argument] on
     failure. *)
-val formula_of_z3 : 'a context -> z3_expr -> 'a formula
+val formula_of_z3 : 'a context -> ?sym_of_decl:(Z3.FuncDecl.func_decl -> symbol) -> 
+  z3_expr -> 'a formula
 
 (** Convert a Z3 expression into an expression.  Raises [Invalid_argument] on
     failure. *)
-val expr_of_z3 : 'a context -> z3_expr -> ('a,typ_fo) expr
+val expr_of_z3 : 'a context -> ?sym_of_decl:(Z3.FuncDecl.func_decl -> symbol) ->
+  z3_expr -> ('a,typ_fo) expr
 
 module Solver : sig
   type 'a t

--- a/srk/src/syntax.ml
+++ b/srk/src/syntax.ml
@@ -513,6 +513,7 @@ let destruct _srk sexpr =
   | Node (App func, args, _) -> `App (func, args)
   | Node (Var (v, `TyReal), [], _) -> `Var (v, `TyReal)
   | Node (Var (v, `TyInt), [], _) -> `Var (v, `TyInt)
+  | Node (Var (v, `TyArr), [], _) -> `Var (v, `TyArr)
   | Node (Var (v, `TyBool), [], _) -> `Proposition (`Var v)
   | Node (Add, sum, _) -> `Add sum
   | Node (Mul, product, _) -> `Mul product

--- a/srk/src/transitionFormula.ml
+++ b/srk/src/transitionFormula.ml
@@ -49,6 +49,10 @@ let formula tf = tf.formula
 let symbols tf = tf.symbols
 let exists tf = tf.exists
 
+let update_formula tf phi = { tf with formula = phi }
+let update_exists tf exists = { tf with exists = exists }
+let update_symbols tf symbols = { tf with symbols = symbols }
+
 let make ?(exists=fun _ -> true) formula symbols =
   { exists; formula; symbols }
 

--- a/srk/src/transitionFormula.mli
+++ b/srk/src/transitionFormula.mli
@@ -42,6 +42,15 @@ val symbols : 'a t -> (symbol * symbol) list
 (** Retrieve the predicate that identifies skolem constants *)
 val exists : 'a t -> (symbol -> bool)
 
+(** Retrieve the underlying formula *)
+val update_formula : 'a t -> 'a formula -> 'a t
+
+(** Retrieve the pre-state/post-state symbols of a transition formula *)
+val update_symbols : 'a t -> (symbol * symbol) list -> 'a t
+
+(** Retrieve the predicate that identifies skolem constants *)
+val update_exists : 'a t -> (symbol -> bool) -> 'a t
+
 (** Retrieve a predicate that identifies symbolic constants *)
 val is_symbolic_constant : 'a t -> symbol -> bool
 

--- a/srk/src/transitionFormula.mli
+++ b/srk/src/transitionFormula.mli
@@ -42,13 +42,13 @@ val symbols : 'a t -> (symbol * symbol) list
 (** Retrieve the predicate that identifies skolem constants *)
 val exists : 'a t -> (symbol -> bool)
 
-(** Retrieve the underlying formula *)
+(** Update the underlying formula *)
 val update_formula : 'a t -> 'a formula -> 'a t
 
-(** Retrieve the pre-state/post-state symbols of a transition formula *)
+(** Update the pre-state/post-state symbols of a transition formula *)
 val update_symbols : 'a t -> (symbol * symbol) list -> 'a t
 
-(** Retrieve the predicate that identifies skolem constants *)
+(** Update the predicate that identifies skolem constants *)
 val update_exists : 'a t -> (symbol -> bool) -> 'a t
 
 (** Retrieve a predicate that identifies symbolic constants *)

--- a/srk/test/test_chc.ml
+++ b/srk/test/test_chc.ml
@@ -7,7 +7,7 @@ open Iteration
 
 let pd = (module QLIALift(Product(LinearRecurrenceInequation)(PolyhedronGuard)) :
   PreDomain)
-
+(*
 let typ_symbol_fo srk sym =
   match typ_symbol srk sym with
   | `TyInt -> `TyInt
@@ -21,183 +21,134 @@ let mk_rel_atom_fresh srk fp ?(name="R") syms =
   mk_rel_atom srk fp rel syms
 
 let mk_n_rel_atoms_fresh srk fp ?(name="R") syms n = 
-  BatArray.init n (fun _ -> mk_rel_atom_fresh srk fp ~name syms)
+  BatArray.init n (fun _ -> mk_rel_atom_fresh srk fp ~name syms)*)
 
 let countup1 () =
-  let fp = Fp.create () in
-  let r1 = mk_relation fp [`TyInt] in
-  let r2 = mk_relation fp [`TyInt] in
-  let error = mk_relation fp [] in
-  let atom1 = mk_rel_atom srk fp r1 [xsym] in
-  let atom2 = mk_rel_atom srk fp r2 [xsym'] in
-  let error_atom = mk_rel_atom srk fp error [] in
-  let () =
+  let r1 = mk_symbol srk ~name:"R1" (`TyFun ([`TyInt], `TyBool)) in
+  let r2 = mk_symbol srk ~name:"R2" (`TyFun ([`TyInt], `TyBool)) in
+  let error = mk_symbol srk ~name:"Error" `TyBool in
+ 
+  let fp = Fp.empty in
+  let prop1 = Proposition.mk_proposition srk r1 ["x"] in
+  let prop2 = Proposition.mk_proposition srk r2 ["x'"] in
+  let errorprop = Proposition.mk_proposition srk error [] in
+  let fp =
     let open Infix in
-    Fp.add_rule fp [atom1] (x' = x + (int 1)) atom2; 
-    Fp.add_rule fp [atom2] (x = x' + (int 1)) atom1;
-    Fp.add_rule fp [] ((int 0) <= x) atom1;
-    Fp.add_rule fp [atom2] (x' <= (int 0)) error_atom;
-    Fp.add_query fp error;
+    Fp.add_rule fp prop2 [prop1] (var 0 `TyInt = var 1 `TyInt + (int 1)) |> 
+    fun fp -> Fp.add_rule fp prop1 [prop2] (var 0 `TyInt = var 1 `TyInt + (int 1)) |>
+    fun fp -> Fp.add_rule fp prop1 [] ((int 0) <= var 0 `TyInt) |>
+    fun fp -> Fp.add_rule fp errorprop [prop2] (var 0 `TyInt <= (int 0)) |>
+    fun fp -> Fp.add_query fp error
   in
   let res = Fp.check srk fp pd in
   assert (res = `No)
 
 let countup2 () =
-  let fp = Fp.create () in
-  let r1 = mk_relation fp [`TyInt] in
-  let r2 = mk_relation fp [`TyInt] in
-  let error = mk_relation fp [] in
-  let atom1 = mk_rel_atom srk fp r1 [xsym] in
-  let atom2 = mk_rel_atom srk fp r2 [xsym'] in
-  let error_atom = mk_rel_atom srk fp error [] in
-  let () =
+  let r1 = mk_symbol srk ~name:"R1" (`TyFun ([`TyInt], `TyBool)) in
+  let r2 = mk_symbol srk ~name:"R2" (`TyFun ([`TyInt], `TyBool)) in
+  let error = mk_symbol srk ~name:"Error" `TyBool in
+ 
+  let fp = Fp.empty in
+  let prop1 = Proposition.mk_proposition srk r1 ["x"] in
+  let prop2 = Proposition.mk_proposition srk r2 ["x'"] in
+  let errorprop = Proposition.mk_proposition srk error [] in
+  let fp =
     let open Infix in
-    Fp.add_rule fp [atom1] (x' = x + (int 1)) atom2;
-    Fp.add_rule fp [atom2] (x = x' + (int 1)) atom1; 
-    Fp.add_rule fp [] ((int 0) <= x) atom1;
-    Fp.add_rule fp [atom2] ((int 0) <= x') error_atom;
-    Fp.add_query fp error;
+    Fp.add_rule fp prop2 [prop1] (var 0 `TyInt = var 1 `TyInt + (int 1)) |> 
+    fun fp -> Fp.add_rule fp prop1 [prop2] (var 0 `TyInt = var 1 `TyInt + (int 1)) |>
+    fun fp -> Fp.add_rule fp prop1 [] ((int 0) <= var 0 `TyInt) |>
+    fun fp -> Fp.add_rule fp errorprop [prop2] ((int 0) <= var 0 `TyInt) |>
+    fun fp -> Fp.add_query fp error
   in
   let res = Fp.check srk fp pd in
   assert (res = `Unknown)
 
+(* x only goes up on some iteration; y goes up on all; verify that if
+ * initially x = y then cannot end with y < x *)
 let xskipcount () =
-  let fp = Fp.create () in
-  let vert = mk_n_rel_atoms_fresh srk fp [xsym; ysym] 3 in
-  let map = [(xsym, xsym'); (ysym, ysym')] in
-  let postify rel_atom = 
-    let syms' = List.map 
-        (fun sym -> 
-           match BatList.assoc_opt sym map with
-           | None -> sym
-           | Some sym' -> sym')
-        (params_of_atom rel_atom)
-    in
-    mk_rel_atom srk fp (rel_of_atom rel_atom) syms'
-  in
-  let () =
-    let open Infix in
-    Fp.add_rule fp [] (y' = x') (postify vert.(0));
-    Fp.add_rule fp [vert.(0)] (x' = x + (int 1) && y' = y) (postify vert.(1));
-    Fp.add_rule fp [vert.(0)] (x' = x && y' = y) (postify vert.(1));
-    Fp.add_rule fp [vert.(1)] (y' = y + (int 1) && x' = x) (postify vert.(0));
-    Fp.add_rule fp [vert.(0)] (y' < x' && x' = x && y' = y) (postify vert.(2));
-    Fp.add_query fp (rel_of_atom vert.(2));
-  in
-  let res = Fp.solve srk fp pd in
-  assert_equiv_formula (snd (res (rel_of_atom (vert.(2))))) (mk_false srk)
+  let r1 = mk_symbol srk ~name:"R1" (`TyFun ([`TyInt; `TyInt], `TyBool)) in
+  let r2 = mk_symbol srk ~name:"R2" (`TyFun ([`TyInt; `TyInt], `TyBool)) in
+  let r3 = mk_symbol srk ~name:"R2" (`TyFun ([`TyInt; `TyInt], `TyBool)) in
 
-let dupuncontrsym () =
-  let fp = Fp.create () in
-  let vert = mk_n_rel_atoms_fresh srk fp [] 2 in
-  let () =
+  let fp = Fp.empty in
+  let prop1 = Proposition.mk_proposition srk r1 ["x"; "y"] in
+  let prop2 = Proposition.mk_proposition srk r2 ["x'"; "y'"] in
+  let prop3 = Proposition.mk_proposition srk r3 ["x''"; "y''"] in
+  let fp =
     let open Infix in
-    Fp.add_rule fp [] (y = (int 1)) vert.(0);
-    Fp.add_rule fp [vert.(0)] (y = (int 0)) vert.(1);
+    Fp.add_rule fp prop1 [] (var 0 `TyInt = var 1 `TyInt) |>
+    fun fp -> Fp.add_rule fp prop2 [prop1] (var 0 `TyInt = var 2 `TyInt + (int 1) && var 1 `TyInt = var 3 `TyInt) |>
+    fun fp -> Fp.add_rule fp prop2 [prop1] (var 0 `TyInt = var 2 `TyInt && var 1 `TyInt = var 3 `TyInt) |>
+    fun fp -> Fp.add_rule fp prop1 [prop2] (var 0 `TyInt = var 2 `TyInt && var 1 `TyInt = var 3 `TyInt + (int 1)) |> 
+    fun fp -> Fp.add_rule fp prop3 [prop1] (var 1 `TyInt < var 0 `TyInt && var 0 `TyInt = var 2 `TyInt && var 1 `TyInt = var 3 `TyInt) |>
+    fun fp -> Fp.add_query fp r3
   in
   let res = Fp.solve srk fp pd in
-  assert_not_implies (snd (res (rel_of_atom vert.(1) ))) (mk_false srk)
+  let phi = mk_exists srk `TyInt (mk_exists srk `TyInt (res (int_of_symbol r3))) in
+  assert_equiv_formula phi (mk_false srk)
 
 let countupsuplin () =
-  let fp = Fp.create () in
-  let r1 = mk_relation fp ~name:"R1" [`TyInt] in
-  let r2 = mk_relation fp ~name:"R2" [`TyInt] in
-  let r3 = mk_relation fp ~name:"R3" [`TyInt] in
+  let r1 = mk_symbol srk ~name:"R1" (`TyFun ([`TyInt], `TyBool)) in
+  let r2 = mk_symbol srk ~name:"R2" (`TyFun ([`TyInt], `TyBool)) in
+  let r3 = mk_symbol srk ~name:"R3" (`TyFun ([`TyInt], `TyBool)) in
+  let error = mk_symbol srk ~name:"Error" `TyBool in
  
-  let error = mk_relation fp [] in
-  let atom1 = mk_rel_atom srk fp r1 [xsym] in
-  let atom2 = mk_rel_atom srk fp r2 [xsym'] in
-  let atom3 = mk_rel_atom srk fp r3 [xsym'] in
-  let error_atom = mk_rel_atom srk fp error [] in
-  let () =
+  let fp = Fp.empty in
+  let prop1 = Proposition.mk_proposition srk r1 ["x"] in
+  let prop2 = Proposition.mk_proposition srk r2 ["y'"] in
+  let prop3 = Proposition.mk_proposition srk r3 ["z''"] in
+  let errorprop = Proposition.mk_proposition srk error [] in
+  let fp =
     let open Infix in
-    Fp.add_rule fp [] (mk_true srk) atom3;
-    Fp.add_rule fp [atom1; atom3] (x' = x + (int 1)) atom2; 
-    Fp.add_rule fp [atom2] (x = x' + (int 1)) atom1;
-    Fp.add_rule fp [] ((int 0) <= x) atom1;
-    Fp.add_rule fp [atom2] (x' <= (int 0)) error_atom;
-    Fp.add_query fp error;
+    Fp.add_rule fp prop3 [] (mk_true srk) |>
+    fun fp -> Fp.add_rule fp prop2 [prop1; prop3] (var 0 `TyInt = var 1 `TyInt + (int 1)) |> 
+    fun fp -> Fp.add_rule fp prop1 [prop2] (var 0 `TyInt = var 1 `TyInt + (int 1)) |>
+    fun fp -> Fp.add_rule fp prop1 [] ((int 0) <= var 0 `TyInt) |>
+    fun fp -> Fp.add_rule fp errorprop [prop2] (var 0 `TyInt <= (int 0)) |>
+    fun fp -> Fp.add_query fp error
   in
   let res = Fp.check srk fp pd in
   assert (res = `No)
 
 let failure_suplin () =
-  let fp = Fp.create () in
-  let r1 = mk_relation fp ~name:"R1" [`TyInt] in
-  let r2 = mk_relation fp ~name:"R2" [`TyInt] in
-  let r3 = mk_relation fp ~name:"R3" [`TyInt] in
+  let r1 = mk_symbol srk ~name:"R1" (`TyFun ([`TyInt], `TyBool)) in
+  let r2 = mk_symbol srk ~name:"R2" (`TyFun ([`TyInt], `TyBool)) in
+  let r3 = mk_symbol srk ~name:"R3" (`TyFun ([`TyInt], `TyBool)) in
+  let error = mk_symbol srk ~name:"Error" `TyBool in
  
-  let error = mk_relation fp [] in
-  let atom1 = mk_rel_atom srk fp r1 [xsym] in
-  let atom2 = mk_rel_atom srk fp r2 [xsym'] in
-  let atom3 = mk_rel_atom srk fp r3 [xsym'] in
-  let error_atom = mk_rel_atom srk fp error [] in
-  let () =
+  let fp = Fp.empty in
+  let prop1 = Proposition.mk_proposition srk r1 ["x"] in
+  let prop2 = Proposition.mk_proposition srk r2 ["y'"] in
+  let prop3 = Proposition.mk_proposition srk r3 ["z''"] in
+  let errorprop = Proposition.mk_proposition srk error [] in
+  let fp =
     let open Infix in
-    Fp.add_rule fp [] (mk_true srk) atom3;
-    Fp.add_rule fp [atom1; atom3] (x' = x + (int 1)) atom2; 
-    Fp.add_rule fp [atom2] (x = x' + (int 1)) atom1;
-    Fp.add_rule fp [] ((int 0) <= x) atom1;
-    Fp.add_rule fp [atom2] (x' <= (int 0)) error_atom;
-    Fp.add_rule fp [atom1] (mk_true srk) atom3;
-    Fp.add_query fp error;
-  in
-  Fp.check srk fp pd
-
-let unbooleanize () =
-  let fp = Fp.create () in
-  let r1 = mk_relation fp [`TyInt; `TyBool] in
-  let r2 = mk_relation fp [`TyInt] in
-  let error = mk_relation fp [] in
-  let atom1 = mk_rel_atom srk fp r1 [xsym; bsym] in
-  let atom2 = mk_rel_atom srk fp r2 [xsym'] in
-  let error_atom = mk_rel_atom srk fp error [] in
-  let () =
-    let open Infix in
-    Fp.add_rule fp [atom1] (x' = x + (int 1) && b) atom2; 
-    Fp.add_rule fp [atom2] (x = x' + (int 1) && b) atom1;
-    Fp.add_rule fp [] ((int 0) <= x && b) atom1;
-    Fp.add_rule fp [atom2] (x' <= (int 0)) error_atom;
-    Fp.add_query fp error;
-  in
-  let (_, fp') = Fp.unbooleanize srk fp in
-  let res = Fp.check srk fp' pd in
-  assert (res = `No)
-
-let failure_unbooleanize () =
-  let fp = Fp.create () in
-  let r1 = mk_relation fp [`TyInt; `TyBool] in
-  let r2 = mk_relation fp [`TyInt] in
-  let error = mk_relation fp [] in
-  let atom1 = mk_rel_atom srk fp r1 [xsym; bsym] in
-  let atom2 = mk_rel_atom srk fp r2 [xsym'] in
-  let error_atom = mk_rel_atom srk fp error [] in
-  let () =
-    let open Infix in
-    Fp.add_rule fp [atom1] (x' = x + (int 1) && b) atom2; 
-    Fp.add_rule fp [atom2] (x = x' + (int 1) && b) atom1;
-    Fp.add_rule fp [] ((int 0) <= x && b) atom1;
-    Fp.add_rule fp [atom2] (x' <= (int 0)) error_atom;
-    Fp.add_query fp error;
+    Fp.add_rule fp prop3 [] (mk_true srk) |>
+    fun fp -> Fp.add_rule fp prop2 [prop1; prop3] (var 0 `TyInt = var 1 `TyInt + (int 1)) |> 
+    fun fp -> Fp.add_rule fp prop1 [prop2] (var 0 `TyInt = var 1 `TyInt + (int 1)) |>
+    fun fp -> Fp.add_rule fp prop1 [] ((int 0) <= var 0 `TyInt) |>
+    fun fp -> Fp.add_rule fp errorprop [prop2] (var 0 `TyInt <= (int 0)) |>
+    fun fp -> Fp.add_rule fp prop3 [prop1] (mk_true srk) |>
+    fun fp -> Fp.add_query fp error
   in
   let res = Fp.check srk fp pd in
   assert (res = `No)
 
-let suite = "Chc" >:::
-  [
 
+let test_init () =
+  let fp = Chc.ChcSrkZ3.parse_file srk "/Users/jakesilverman/Documents/arraycopy2.smt2" in
+  Log.errorf "Fp is \n%a\n\n\n\n" (Chc.Fp.pp srk) fp;
+  assert false
+  
+  let suite = "Chc" >:::
+  [
+    (*"test_init" >:: test_init;*)
     "countup1" >:: countup1;
     "counterup2" >:: countup2;
     "xskipcount" >:: xskipcount;
-    "dupunconstrsym" >:: dupuncontrsym;
     "countupsuplin" >:: countupsuplin;
     "failure_suplin" >:: (fun _ -> 
         assert_raises 
           (Failure "No methods for solving non super linear chc systems") 
           failure_suplin);
-    "unbooleanize" >:: unbooleanize;
-    "failure_unbooleanize" >:: (fun _ -> 
-        assert_raises 
-          (Invalid_argument "SrkApon: environment symbols must be number-typed") 
-          failure_unbooleanize);
   ]

--- a/srk/test/test_pervasives.ml
+++ b/srk/test/test_pervasives.ml
@@ -22,6 +22,9 @@ let q : 'a arith_term = Ctx.mk_const qsym
 let r : 'a arith_term = Ctx.mk_const rsym
 let s : 'a arith_term = Ctx.mk_const ssym
 
+let bsym = Ctx.mk_symbol ~name:"b" `TyBool
+let b : 'a formula = Ctx.mk_const bsym
+
 let vsym = Ctx.mk_symbol ~name:"v" `TyInt
 let wsym = Ctx.mk_symbol ~name:"w" `TyInt
 let xsym = Ctx.mk_symbol ~name:"x" `TyInt


### PR DESCRIPTION
…g. QLIALift. Various chc helper functions

Note that this push add a few "TODOS" for locations that need to be touched up after the arrays as first order types is pushed. Additionally, it adds a "construct" function to the Formula module that duplicates a function that already exists in the arrays as first order types PR.