### PR TITLE
[GPS] add extrapolate, refactor interpolate in srk

### DIFF
--- a/srk/src/quantifier.ml
+++ b/srk/src/quantifier.ml
@@ -1832,7 +1832,7 @@ let _orient project eqs =
   in
   go eqs []
 
-let mbp ?(dnf=false) srk exists phi =
+let mbp ?(dnf=false) srk ?(solver=Smt.mk_solver ~theory:"QF_LIA" srk) exists phi =
   let phi =
     eliminate_ite srk phi
     |> rewrite srk
@@ -1848,7 +1848,6 @@ let mbp ?(dnf=false) srk exists phi =
       project
       IntSet.empty
   in
-  let solver = Smt.mk_solver ~theory:"QF_LIA" srk in
   let disjuncts = ref [] in
   let is_true phi =
     match Formula.destruct srk phi with

--- a/srk/src/quantifier.mli
+++ b/srk/src/quantifier.mli
@@ -20,7 +20,7 @@ val qe_mbp : 'a context -> 'a formula -> 'a formula
 
 (** Model-based projection.  If [dnf] option is set, convert to
    disjunctive normal form. *)
-val mbp : ?dnf:bool -> 'a context -> (symbol -> bool) -> 'a formula -> 'a formula
+val mbp : ?dnf:bool -> 'a context -> ?solver:'a Smt.Solver.t -> (symbol -> bool) -> 'a formula -> 'a formula
 
 (** Over-approximtate model-based projection.  If [dnf] option is set,
    convert to disjunctive normal form. *)

--- a/srk/src/smt.ml
+++ b/srk/src/smt.ml
@@ -7,8 +7,8 @@ module Solver = SrkZ3.Solver
 
 let mk_solver ?(theory="") srk = SrkZ3.mk_solver ~theory srk
 
-let get_model ?(symbols=[]) srk phi =
-  let solver = mk_solver srk in
+let get_model ?(symbols=[]) srk ?(solver=mk_solver srk) phi =
+  let _ = Solver.reset solver in 
   Solver.add solver [phi];
   Solver.get_model ~symbols solver
 

--- a/srk/src/smt.mli
+++ b/srk/src/smt.mli
@@ -31,11 +31,12 @@ val mk_solver : ?theory:string -> 'a context -> 'a Solver.t
     evaluate terms, but its bindings may not be enumerated (see
     [Interpretation] for more detail). *)
 val get_model : ?symbols:(symbol list) ->
-  'a context ->
+  'a context -> ?solver:'a Solver.t -> 
   'a formula ->
   [ `Sat of 'a interpretation
   | `Unsat
   | `Unknown ]
+    
 
 (** Compute a model of a formula, and return an intepretation that binds the
     specified subset of symbols.  If the symbol list contains all symbols of

--- a/srk/src/smt.mli
+++ b/srk/src/smt.mli
@@ -24,11 +24,11 @@ module Solver : sig
     ('a formula) list ->
     [ `Sat | `Unsat of ('a formula) list | `Unknown ]
 
-  val get_unsat_core_or_concrete_model : 'a t -> ('a formula) list -> symbol list -> 
+  val get_unsat_core_or_model : ?symbols:symbol list -> 'a t -> ('a formula) list -> 
     [ `Sat of 'a interpretation 
       | `Unsat of ('a formula) list 
-      | `Unknown ]  
-end
+      | `Unknown ]
+  end
 
 val mk_solver : ?theory:string -> 'a context -> 'a Solver.t
 

--- a/srk/src/smt.mli
+++ b/srk/src/smt.mli
@@ -23,6 +23,11 @@ module Solver : sig
   val get_unsat_core : 'a t ->
     ('a formula) list ->
     [ `Sat | `Unsat of ('a formula) list | `Unknown ]
+
+  val get_unsat_core_or_concrete_model : 'a t -> ('a formula) list -> symbol list -> 
+    [ `Sat of 'a interpretation 
+      | `Unsat of ('a formula) list 
+      | `Unknown ]  
 end
 
 val mk_solver : ?theory:string -> 'a context -> 'a Solver.t

--- a/srk/src/srkZ3.ml
+++ b/srk/src/srkZ3.ml
@@ -562,7 +562,7 @@ module Solver = struct
     | `Unsat ->
       `Unsat (List.map solver.formula_of (Z3.Solver.get_unsat_core solver.s))
 
-  let get_unsat_core_or_concrete_model solver assumptions symbols = 
+  let get_unsat_core_or_model ?(symbols=[]) solver assumptions = 
     let srk = solver.srk in 
     let z3 = solver.z3 in
     match check solver assumptions with 

--- a/srk/src/srkZ3.ml
+++ b/srk/src/srkZ3.ml
@@ -562,6 +562,19 @@ module Solver = struct
     | `Unsat ->
       `Unsat (List.map solver.formula_of (Z3.Solver.get_unsat_core solver.s))
 
+  let get_unsat_core_or_concrete_model solver assumptions symbols = 
+    let srk = solver.srk in 
+    let z3 = solver.z3 in
+    match check solver assumptions with 
+    | `Sat -> 
+      begin match Z3.Solver.get_model solver.s with 
+        | Some m -> `Sat (Interpretation.wrap ~symbols srk (model_get_value srk z3 m))
+        | None -> `Unknown 
+      end
+    | `Unknown -> `Unknown 
+    | `Unsat -> 
+      `Unsat (List.map solver.formula_of (Z3.Solver.get_unsat_core solver.s))
+
   let get_reason_unknown solver = Z3.Solver.get_reason_unknown solver.s
 end
 

--- a/srk/src/srkZ3.mli
+++ b/srk/src/srkZ3.mli
@@ -76,6 +76,11 @@ module Solver : sig
     ('a formula) list ->
     [ `Sat | `Unsat of ('a formula) list | `Unknown ]
 
+  val get_unsat_core_or_concrete_model : 'a t -> ('a formula) list -> symbol list -> 
+    [ `Sat of 'a interpretation 
+      | `Unsat of ('a formula) list 
+      | `Unknown ]
+  
   val get_reason_unknown : 'a t -> string
 end
 

--- a/srk/src/srkZ3.mli
+++ b/srk/src/srkZ3.mli
@@ -76,7 +76,7 @@ module Solver : sig
     ('a formula) list ->
     [ `Sat | `Unsat of ('a formula) list | `Unknown ]
 
-  val get_unsat_core_or_concrete_model : 'a t -> ('a formula) list -> symbol list -> 
+  val get_unsat_core_or_model : ?symbols: symbol list -> 'a t -> ('a formula) list -> 
     [ `Sat of 'a interpretation 
       | `Unsat of ('a formula) list 
       | `Unknown ]

--- a/srk/src/transition.ml
+++ b/srk/src/transition.ml
@@ -544,8 +544,6 @@ struct
     in
       match Smt.get_model ~solver:solver ~symbols:symbols_conj srk conj with 
       | `Sat m -> 
-        Interpretation.pp Format.std_formatter m ;
-        Format.print_flush ();
         let pre_, post_ = extrapolate_project srk ss_t1 ss_t3 symbols_t1_t2 symbols_t3_t2 m in 
           (* Perform reverse-renaming to de-subscript variables based on reverse lookup table *)
           let reverse_substitute symb = 

--- a/srk/src/transition.ml
+++ b/srk/src/transition.ml
@@ -448,6 +448,114 @@ struct
        in
        `Valid (List.tl itp)
 
+  let extrapolate ?(solver=Smt.mk_solver srk) t1 t2 t3 : [`Sat of (C.t formula * C.t formula) | `Unsat ] =
+    (* Create fresh copies of skolem variables: nondet consts, loop tripcount variables, etc. *)
+    let t1, t2, t3 =
+      let refresh = (fun tr ->
+                  let fresh_skolem =
+                    Memo.memo (fun sym ->
+                        match Var.of_symbol sym with
+                        | Some _ -> mk_const srk sym
+                        | None ->
+                          let name = show_symbol srk sym in
+                          let typ = typ_symbol srk sym in
+                          mk_const srk (mk_symbol srk ~name typ))
+                  in
+                  { transform = M.map (substitute_const srk fresh_skolem) tr.transform;
+                    guard = substitute_const srk fresh_skolem tr.guard }) 
+    in refresh t1, refresh t2, refresh t3 
+    (* Perform variable subscripting; equivalent to "SSA"ing the formulas t1, t2, t3 *)
+    in let subscript_tbl = Hashtbl.create 991 in
+    let reverse_subscript_tbl = Hashtbl.create 991 in 
+    let subscript sym =
+      try
+        Hashtbl.find subscript_tbl sym
+      with Not_found -> mk_const srk sym
+    in
+    (* Same as interpolation: Convert tr into a formula, and simultaneously update the subscript table *)
+    let to_ss_formula tr =
+      let ss_guard = substitute_const srk subscript (guard tr)
+      in let (ss, phis) =
+        M.fold (fun var term (ss, phis) ->
+            let var_sym = Var.symbol_of var in
+            let var_ss_sym = mk_symbol srk (Var.typ var :> typ) in
+            let var_ss_term = mk_const srk var_ss_sym in
+            let term_ss = substitute_const srk subscript term in
+            ((var_sym, var_ss_term, var_ss_sym)::ss,
+              (mk_eq srk var_ss_term term_ss)::phis))
+          tr.transform
+          ([], [ ss_guard ])
+      in
+      List.iter (fun (k, v, l) -> Hashtbl.add subscript_tbl k v; Hashtbl.add reverse_subscript_tbl l k) ss;
+      mk_and srk phis
+    in let ss_t1 = to_ss_formula t1 
+    in let ss_t2 = to_ss_formula t2 
+    in let ss_t3 = to_ss_formula t3 
+    in let conj = mk_and srk [ss_t1; ss_t2; ss_t3]
+    (* Get variables in the intersection of vocabularues of (t1, t2) and (t3, t2) *)
+    in let symbols_t1_t2 = 
+      let symbt1 = Syntax.symbols ss_t1 in 
+      let symbt2 = Syntax.symbols ss_t2 in 
+      let symbt1t2 = Symbol.Set.diff symbt1 symbt2 in 
+      symbt1t2 |> Symbol.Set.elements 
+    in let symbols_t3_t2 = 
+      let symbt3 = Syntax.symbols ss_t3 in 
+      let symbt2 = Syntax.symbols ss_t2 in 
+      let symbt3t2 = Symbol.Set.diff symbt3 symbt2 in 
+      symbt3t2 |> Symbol.Set.elements 
+    in let symbols_conj = Syntax.symbols conj |> Symbol.Set.elements 
+    (* aux routine for doing projection operations using Srk.polyhedron *)
+    in let extrapolate_project srk (f1: 'a formula) (f3: 'a formula) symbols_f1 symbols_f3 model = 
+      (* first do NNF conversion on f1, f3 before computing their implicants *)
+      let nnf_rewriter = Syntax.pos_rewriter srk in
+      let f1 = Syntax.rewrite srk ~down:(nnf_rewriter) f1 in 
+      let f3 = Syntax.rewrite srk ~down:(nnf_rewriter) f3 in 
+      let implicant_f1_o = Interpretation.select_implicant model f1 in 
+      let implicant_f3_o = Interpretation.select_implicant model f3 in 
+        match implicant_f1_o, implicant_f3_o with 
+        | Some if1, Some if3 ->
+          let cube_f1 = Polyhedron.of_cube srk if1 in 
+          let cube_f3 = Polyhedron.of_cube srk if3 in 
+          let value_of_coord = (* coord (int) -> x (symbol) -> m[x] (value in R) *)
+            fun coord ->
+              Syntax.symbol_of_int coord 
+              |> Interpretation.real model
+          in let xs_f1 = List.map Syntax.int_of_symbol symbols_f1 
+          in let xs_f3 = List.map Syntax.int_of_symbol symbols_f3
+          in let f1_projected = Polyhedron.local_project value_of_coord xs_f1 cube_f1
+          in let f3_projected = Polyhedron.local_project value_of_coord xs_f3 cube_f3
+          in
+            (Polyhedron.cube_of srk f1_projected |> Syntax.mk_and srk, 
+             Polyhedron.cube_of srk f3_projected |> Syntax.mk_and srk)
+        | _ -> failwith "error extrapolating: select_implicant returned None"
+    in
+      match Smt.get_model ~solver:solver ~symbols:symbols_conj srk conj with 
+      | `Sat m -> 
+        Printf.printf "extrapolate: result is SAT, got model\n";
+        Interpretation.pp Format.std_formatter m ;
+        Format.print_flush ();
+        let pre_, post_ = extrapolate_project srk ss_t1 ss_t3 symbols_t1_t2 symbols_t3_t2 m in 
+          (* Perform reverse-renaming to de-subscript variables based on reverse lookup table *)
+          let reverse_substitute symb = 
+            try 
+              let sym = Hashtbl.find reverse_subscript_tbl symb in 
+                mk_const srk sym 
+            with Not_found -> 
+                Printf.printf  " not found symbol %s\n" (Syntax.show_symbol srk symb); mk_const srk symb
+          in 
+          let ex1 = (substitute_const srk (reverse_substitute) pre_) in 
+          let ex2 = (substitute_const srk (reverse_substitute) post_) in 
+          Printf.printf "\npre extrapolant after renaming: ";
+          Syntax.pp_expr_unnumbered srk Format.std_formatter ex1;
+          Format.print_flush();
+          Printf.printf "\npost extrapolant after renaming: ";
+          Syntax.pp_expr_unnumbered srk Format.std_formatter ex2;
+          Format.print_flush();
+          Printf.printf "\n--------------------------\n";  
+          `Sat (ex1, ex2) 
+      | _ -> `Unsat (* failed; [t1 * t2 * t3] is UNSAT so unable to project. *)
+
+
   let valid_triple phi path post =
     let path_not_post = List.fold_right mul path (assume (mk_not srk post)) in
     match Smt.is_sat srk (mk_and srk [phi; path_not_post.guard]) with

--- a/srk/src/transition.ml
+++ b/srk/src/transition.ml
@@ -544,7 +544,6 @@ struct
     in
       match Smt.get_model ~solver:solver ~symbols:symbols_conj srk conj with 
       | `Sat m -> 
-        Printf.printf "extrapolate: result is SAT, got model\n";
         Interpretation.pp Format.std_formatter m ;
         Format.print_flush ();
         let pre_, post_ = extrapolate_project srk ss_t1 ss_t3 symbols_t1_t2 symbols_t3_t2 m in 
@@ -553,18 +552,10 @@ struct
             try 
               let sym = Hashtbl.find reverse_subscript_tbl symb in 
                 mk_const srk sym 
-            with Not_found -> 
-                Printf.printf  " not found symbol %s\n" (Syntax.show_symbol srk symb); mk_const srk symb
+            with Not_found -> mk_const srk symb
           in 
           let ex1 = (substitute_const srk (reverse_substitute) pre_) in 
           let ex2 = (substitute_const srk (reverse_substitute) post_) in 
-          Printf.printf "\npre extrapolant after renaming: ";
-          Syntax.pp_expr_unnumbered srk Format.std_formatter ex1;
-          Format.print_flush();
-          Printf.printf "\npost extrapolant after renaming: ";
-          Syntax.pp_expr_unnumbered srk Format.std_formatter ex2;
-          Format.print_flush();
-          Printf.printf "\n--------------------------\n";  
           `Sat (ex1, ex2) 
       | _ -> `Unsat (* failed; [t1 * t2 * t3] is UNSAT so unable to project. *)
 

--- a/srk/src/transition.ml
+++ b/srk/src/transition.ml
@@ -342,7 +342,23 @@ struct
     | `And xs -> List.concat_map (destruct_and srk) xs
     | _ -> [phi]
 
-  let interpolate_unsat_core solver' trs post guards core = 
+  (* helper method for interpolate/extrapolate procedures. creates fresh copies of skolem variables in tr *)
+  let rename_skolems tr =
+    let fresh_skolem =
+      Memo.memo (fun sym ->
+          match Var.of_symbol sym with
+          | Some _ -> mk_const srk sym
+          | None ->
+              let name = show_symbol srk sym in
+              let typ = typ_symbol srk sym in
+              mk_const srk (mk_symbol srk ~name typ))
+    in
+    { transform = M.map (substitute_const srk fresh_skolem) tr.transform;
+      guard = substitute_const srk fresh_skolem tr.guard }
+
+
+
+  let interpolate_unsat_core solver trs post guards core = 
     let refresh s = Smt.Solver.reset s; s 
     in let core_symbols =
       List.fold_left (fun core phi ->
@@ -374,7 +390,7 @@ struct
           in
           let wp =
             (mk_not srk (mk_or srk (post'::reduced_guard)))
-            |> Quantifier.mbp srk ~solver:(refresh solver') (fun s -> Var.of_symbol s != None)
+            |> Quantifier.mbp srk ~solver:(refresh solver) (fun s -> Var.of_symbol s != None)
             |> mk_not srk
           in
           (wp::itp, wp))
@@ -386,33 +402,20 @@ struct
 
   let interpolate_query ?(solver=Smt.mk_solver C.context) trs post sat_callback unsat_callback = 
     let _ = Smt.Solver.reset solver in 
-    let trs =
-      trs |> List.map (fun tr ->
-                  let fresh_skolem =
-                    Memo.memo (fun sym ->
-                        match Var.of_symbol sym with
-                        | Some _ -> mk_const srk sym
-                        | None ->
-                          let name = show_symbol srk sym in
-                          let typ = typ_symbol srk sym in
-                          mk_const srk (mk_symbol srk ~name typ))
-                  in
-                  { transform = M.map (substitute_const srk fresh_skolem) tr.transform;
-                    guard = substitute_const srk fresh_skolem tr.guard })
-    in
     (* Break guards into conjunctions, associate each conjunct with an indicator *)
     let guards =
       List.map (fun tr ->
           List.map
             (fun phi -> (mk_symbol srk `TyBool, phi))
             (destruct_and srk tr.guard))
-        trs
-    in
-    let indicators =
-      List.concat_map (List.map (fun (s, _) -> mk_const srk s)) guards
+        trs in 
+    let indicators, indicator_symbols =
+      List.concat_map (List.map (fun (s, _) -> mk_const srk s)) guards,
+      List.concat_map (List.map fst) guards |> Symbol.Set.of_list
     in
     let subscript_tbl = Hashtbl.create 991 in
     let ss_inv = Hashtbl.create 991 in 
+    let sst = Hashtbl.create 991 in 
     let subscript sym =
       try
         Hashtbl.find subscript_tbl sym
@@ -441,121 +444,152 @@ struct
       in
       List.iter (fun (k, l, v) -> 
         Hashtbl.add subscript_tbl k v;
-        Hashtbl.add ss_inv l k) ss;
+        Hashtbl.add ss_inv l k;
+        Hashtbl.add sst k l) ss;
       mk_and srk phis
     in
-    let target = substitute_const srk subscript (mk_not srk post) in 
+    (* gather all symbols into a list, while adding formulas to the solver object *) 
     let symbols = List.fold_left 
       (fun symbols (tr, guard) ->
         let f = to_ss_formula tr guard in 
           Smt.Solver.add solver [f];
-          (Syntax.symbols f |> Symbol.Set.elements) @ symbols)
-        (Syntax.symbols target |> Symbol.Set.elements) (List.combine trs guards) in 
-    Smt.Solver.add solver [target];
-    match Smt.Solver.get_unsat_core_or_concrete_model solver indicators symbols with 
-      | `Sat m -> (sat_callback m ss_inv)
-      | `Unsat core -> (unsat_callback trs post guards core)
-      | `Unknown -> `Unknown 
+          (Syntax.symbols f) :: symbols)
+        [] (List.combine trs guards) 
+        |> List.rev
+        |> List.map (fun ss -> Symbol.Set.diff ss indicator_symbols) in 
+    (* subscript the symbols in the `post` formula, as well *)
+    let target = substitute_const srk subscript (mk_not srk post) in
+      Smt.Solver.add solver [target];
+      match Smt.Solver.get_unsat_core_or_model solver indicators with 
+        | `Sat m ->  
+          (sat_callback m symbols ss_inv)
+        | `Unsat core -> (unsat_callback trs post guards core)
+        | `Unknown -> `Unknown 
+
+
 
   let interpolate ?(solver=Smt.mk_solver C.context) ?(qflia_solver=(Smt.mk_solver ~theory:"QF_LIA" srk)) trs post =
     Smt.Solver.reset solver;
-    interpolate_query ~solver:solver trs post (fun _ _ -> `Invalid) @@ interpolate_unsat_core qflia_solver
+    let trs = List.map rename_skolems trs in 
+    interpolate_query ~solver:solver trs post (fun _ _ _ -> `Invalid) @@ interpolate_unsat_core qflia_solver
+
+  let interpolate_or_concrete_model ?(solver=Smt.mk_solver C.context) ?(qflia_solver=(Smt.mk_solver ~theory:"QF_LIA" srk)) trs post = 
+    (* subst_model: rename skolem constants back to their appropriate names using reverse subscript table *)
+    Smt.Solver.reset solver;
+    let trs = List.map rename_skolems trs in 
+    let sat_model model (symbols: Symbol.Set.t list) ss_inv = 
+        let m = 
+          List.fold_left (fun m' symbols -> 
+            Symbol.Set.fold (fun s m -> 
+              (* the provided model is over both subscripted vocabulary and original vocabulary *)
+              begin match Hashtbl.find_opt ss_inv s with 
+              | Some s' -> (* subscripted variable *)
+                Interpretation.add s' (Interpretation.value model s) m
+              |  None -> (* non-subscripted; query directly *)
+                Interpretation.add s (Interpretation.value model s)  m 
+              end) symbols m'
+          ) (Interpretation.empty srk) symbols in 
+        (* symbols is a list of subscripted symbols arranged in left-to-right order. 
+          folding over this in left-to-right order amounts to forward concrete execution. *)
+        `Invalid m
+    in interpolate_query ~solver:solver trs post sat_model @@ interpolate_unsat_core qflia_solver
+
 
   let extrapolate ?(solver=Smt.mk_solver srk) t1 t2 t3 : [`Sat of (C.t formula * C.t formula) | `Unsat ] =
-    (* Create fresh copies of skolem variables: nondet consts, loop tripcount variables, etc. *)
-    let t1, t2, t3 =
-      let refresh = (fun tr ->
-                  let fresh_skolem =
-                    Memo.memo (fun sym ->
-                        match Var.of_symbol sym with
-                        | Some _ -> mk_const srk sym
-                        | None ->
-                          let name = show_symbol srk sym in
-                          let typ = typ_symbol srk sym in
-                          mk_const srk (mk_symbol srk ~name typ))
-                  in
-                  { transform = M.map (substitute_const srk fresh_skolem) tr.transform;
-                    guard = substitute_const srk fresh_skolem tr.guard }) 
-    in refresh t1, refresh t2, refresh t3 
-    (* Perform variable subscripting; equivalent to "SSA"ing the formulas t1, t2, t3 *)
-    in let subscript_tbl = Hashtbl.create 991 in
-    let reverse_subscript_tbl = Hashtbl.create 991 in 
-    let subscript sym =
-      try
-        Hashtbl.find subscript_tbl sym
-      with Not_found -> mk_const srk sym
+  (* Create fresh copies of skolem variables: nondet consts, loop tripcount variables, etc. *)
+  let t1, t2, t3 =
+    let refresh = (fun tr ->
+                let fresh_skolem =
+                  Memo.memo (fun sym ->
+                      match Var.of_symbol sym with
+                      | Some _ -> mk_const srk sym
+                      | None ->
+                        let name = show_symbol srk sym in
+                        let typ = typ_symbol srk sym in
+                        mk_const srk (mk_symbol srk ~name typ))
+                in
+                { transform = M.map (substitute_const srk fresh_skolem) tr.transform;
+                  guard = substitute_const srk fresh_skolem tr.guard }) 
+  in refresh t1, refresh t2, refresh t3 
+  (* Perform variable subscripting; equivalent to "SSA"ing the formulas t1, t2, t3 *)
+  in let subscript_tbl = Hashtbl.create 991 in
+  let reverse_subscript_tbl = Hashtbl.create 991 in 
+  let subscript sym =
+    try
+      Hashtbl.find subscript_tbl sym
+    with Not_found -> mk_const srk sym
+  in
+  (* Same as interpolation: Convert tr into a formula, and simultaneously update the subscript table *)
+  let to_ss_formula tr =
+    let ss_guard = substitute_const srk subscript (guard tr)
+    in let (ss, phis) =
+      M.fold (fun var term (ss, phis) ->
+          let var_sym = Var.symbol_of var in
+          let var_ss_sym = mk_symbol srk (Var.typ var :> typ) in
+          let var_ss_term = mk_const srk var_ss_sym in
+          let term_ss = substitute_const srk subscript term in
+          ((var_sym, var_ss_term, var_ss_sym)::ss,
+            (mk_eq srk var_ss_term term_ss)::phis))
+        tr.transform
+        ([], [ ss_guard ])
     in
-    (* Same as interpolation: Convert tr into a formula, and simultaneously update the subscript table *)
-    let to_ss_formula tr =
-      let ss_guard = substitute_const srk subscript (guard tr)
-      in let (ss, phis) =
-        M.fold (fun var term (ss, phis) ->
-            let var_sym = Var.symbol_of var in
-            let var_ss_sym = mk_symbol srk (Var.typ var :> typ) in
-            let var_ss_term = mk_const srk var_ss_sym in
-            let term_ss = substitute_const srk subscript term in
-            ((var_sym, var_ss_term, var_ss_sym)::ss,
-              (mk_eq srk var_ss_term term_ss)::phis))
-          tr.transform
-          ([], [ ss_guard ])
-      in
-      List.iter (fun (k, v, l) -> Hashtbl.add subscript_tbl k v; Hashtbl.add reverse_subscript_tbl l k) ss;
-      mk_and srk phis
-    in let ss_t1 = to_ss_formula t1 
-    in let ss_t2 = to_ss_formula t2 
-    in let ss_t3 = to_ss_formula t3 
-    in let conj = mk_and srk [ss_t1; ss_t2; ss_t3]
-    (* Get variables in the intersection of vocabularues of (t1, t2) and (t3, t2) *)
-    in let symbols_t1_t2 = 
-      let symbt1 = Syntax.symbols ss_t1 in 
-      let symbt2 = Syntax.symbols ss_t2 in 
-      let symbt1t2 = Symbol.Set.diff symbt1 symbt2 in 
-      symbt1t2 |> Symbol.Set.elements 
-    in let symbols_t3_t2 = 
-      let symbt3 = Syntax.symbols ss_t3 in 
-      let symbt2 = Syntax.symbols ss_t2 in 
-      let symbt3t2 = Symbol.Set.diff symbt3 symbt2 in 
-      symbt3t2 |> Symbol.Set.elements 
-    in let symbols_conj = Syntax.symbols conj |> Symbol.Set.elements 
-    (* aux routine for doing projection operations using Srk.polyhedron *)
-    in let extrapolate_project srk (f1: 'a formula) (f3: 'a formula) symbols_f1 symbols_f3 model = 
-      (* first do NNF conversion on f1, f3 before computing their implicants *)
-      let nnf_rewriter = Syntax.pos_rewriter srk in
-      let f1 = Syntax.rewrite srk ~down:(nnf_rewriter) f1 in 
-      let f3 = Syntax.rewrite srk ~down:(nnf_rewriter) f3 in 
-      let implicant_f1_o = Interpretation.select_implicant model f1 in 
-      let implicant_f3_o = Interpretation.select_implicant model f3 in 
-        match implicant_f1_o, implicant_f3_o with 
-        | Some if1, Some if3 ->
-          let cube_f1 = Polyhedron.of_cube srk if1 in 
-          let cube_f3 = Polyhedron.of_cube srk if3 in 
-          let value_of_coord = (* coord (int) -> x (symbol) -> m[x] (value in R) *)
-            fun coord ->
-              Syntax.symbol_of_int coord 
-              |> Interpretation.real model
-          in let xs_f1 = List.map Syntax.int_of_symbol symbols_f1 
-          in let xs_f3 = List.map Syntax.int_of_symbol symbols_f3
-          in let f1_projected = Polyhedron.local_project value_of_coord xs_f1 cube_f1
-          in let f3_projected = Polyhedron.local_project value_of_coord xs_f3 cube_f3
-          in
-            (Polyhedron.cube_of srk f1_projected |> Syntax.mk_and srk, 
-             Polyhedron.cube_of srk f3_projected |> Syntax.mk_and srk)
-        | _ -> failwith "error extrapolating: select_implicant returned None"
-    in
-      match Smt.get_model ~solver:solver ~symbols:symbols_conj srk conj with 
-      | `Sat m -> 
-        let pre_, post_ = extrapolate_project srk ss_t1 ss_t3 symbols_t1_t2 symbols_t3_t2 m in 
-          (* Perform reverse-renaming to de-subscript variables based on reverse lookup table *)
-          let reverse_substitute symb = 
-            try 
-              let sym = Hashtbl.find reverse_subscript_tbl symb in 
-                mk_const srk sym 
-            with Not_found -> mk_const srk symb
-          in 
-          let ex1 = (substitute_const srk (reverse_substitute) pre_) in 
-          let ex2 = (substitute_const srk (reverse_substitute) post_) in 
-          `Sat (ex1, ex2) 
-      | _ -> `Unsat (* failed; [t1 * t2 * t3] is UNSAT so unable to project. *)
+    List.iter (fun (k, v, l) -> Hashtbl.add subscript_tbl k v; Hashtbl.add reverse_subscript_tbl l k) ss;
+    mk_and srk phis
+  in let ss_t1 = to_ss_formula t1 
+  in let ss_t2 = to_ss_formula t2 
+  in let ss_t3 = to_ss_formula t3 
+  in let conj = mk_and srk [ss_t1; ss_t2; ss_t3]
+  (* Get variables in the intersection of vocabularues of (t1, t2) and (t3, t2) *)
+  in let symbols_t1_t2 = 
+    let symbt1 = Syntax.symbols ss_t1 in 
+    let symbt2 = Syntax.symbols ss_t2 in 
+    let symbt1t2 = Symbol.Set.diff symbt1 symbt2 in 
+    symbt1t2 |> Symbol.Set.elements 
+  in let symbols_t3_t2 = 
+    let symbt3 = Syntax.symbols ss_t3 in 
+    let symbt2 = Syntax.symbols ss_t2 in 
+    let symbt3t2 = Symbol.Set.diff symbt3 symbt2 in 
+    symbt3t2 |> Symbol.Set.elements 
+  in let symbols_conj = Syntax.symbols conj |> Symbol.Set.elements 
+  (* aux routine for doing projection operations using Srk.polyhedron *)
+  in let extrapolate_project srk (f1: 'a formula) (f3: 'a formula) symbols_f1 symbols_f3 model = 
+    (* first do NNF conversion on f1, f3 before computing their implicants *)
+    let nnf_rewriter = Syntax.pos_rewriter srk in
+    let f1 = Syntax.rewrite srk ~down:(nnf_rewriter) f1 in 
+    let f3 = Syntax.rewrite srk ~down:(nnf_rewriter) f3 in 
+    let implicant_f1_o = Interpretation.select_implicant model f1 in 
+    let implicant_f3_o = Interpretation.select_implicant model f3 in 
+      match implicant_f1_o, implicant_f3_o with 
+      | Some if1, Some if3 ->
+        let cube_f1 = Polyhedron.of_cube srk if1 in 
+        let cube_f3 = Polyhedron.of_cube srk if3 in 
+        let value_of_coord = (* coord (int) -> x (symbol) -> m[x] (value in R) *)
+          fun coord ->
+            Syntax.symbol_of_int coord 
+            |> Interpretation.real model
+        in let xs_f1 = List.map Syntax.int_of_symbol symbols_f1 
+        in let xs_f3 = List.map Syntax.int_of_symbol symbols_f3
+        in let f1_projected = Polyhedron.local_project value_of_coord xs_f1 cube_f1
+        in let f3_projected = Polyhedron.local_project value_of_coord xs_f3 cube_f3
+        in
+          (Polyhedron.cube_of srk f1_projected |> Syntax.mk_and srk, 
+            Polyhedron.cube_of srk f3_projected |> Syntax.mk_and srk)
+      | _ -> failwith "error extrapolating: select_implicant returned None"
+  in
+    match Smt.get_model ~solver:solver ~symbols:symbols_conj srk conj with 
+    | `Sat m -> 
+      let pre_, post_ = extrapolate_project srk ss_t1 ss_t3 symbols_t1_t2 symbols_t3_t2 m in 
+        (* Perform reverse-renaming to de-subscript variables based on reverse lookup table *)
+        let reverse_substitute symb = 
+          try 
+            let sym = Hashtbl.find reverse_subscript_tbl symb in 
+              mk_const srk sym 
+          with Not_found -> mk_const srk symb
+        in 
+        let ex1 = (substitute_const srk (reverse_substitute) pre_) in 
+        let ex2 = (substitute_const srk (reverse_substitute) post_) in 
+        `Sat (ex1, ex2) 
+    | _ -> `Unsat (* failed; [t1 * t2 * t3] is UNSAT so unable to project. *)
 
 
   let valid_triple phi path post =

--- a/srk/src/transition.mli
+++ b/srk/src/transition.mli
@@ -114,6 +114,12 @@ module Make
                                 | `Invalid
                                 | `Unknown ]
 
+  (** Same as interpolate, but returns a concrete model if interpllation fails. *)
+  val interpolate_or_concrete_model : ?solver:(C.t Smt.Solver.t) -> ?qflia_solver:(C.t Smt.Solver.t) 
+    -> t list -> C.t formula -> [`Valid of C.t formula list 
+                                | `Invalid of C.t Interpretation.interpretation 
+                                | `Unknown ]
+
   (** Extrapolation operation as defined in Ruijie Fang's undergraduate thesis  
       "Software Model Checking with Path and Procedure Summaries", Princeton, 2023. 
       Given 3 transition formulas t1, t2, t3, such that [t1 * t2 * t3] is SAT, 

--- a/srk/src/transition.mli
+++ b/srk/src/transition.mli
@@ -109,10 +109,10 @@ module Make
       return a sequence of intermediate assertions [phi_1 ... phi_n] that
       support the proof (for each [i], [{ phi_{i-1} } tr_i { phi_i }] holds,
       where [phi_0] is [true] and [phi_n] implies the post-condition). *)
-
-  val interpolate : t list -> C.t formula -> [ `Valid of C.t formula list
-                                             | `Invalid
-                                             | `Unknown ]
+  val interpolate : ?solver:(C.t Smt.Solver.t) -> ?qflia_solver:(C.t Smt.Solver.t) 
+    -> t list -> C.t formula -> [ `Valid of C.t formula list
+                                | `Invalid
+                                | `Unknown ]
 
   (** Extrapolation operation as defined in Ruijie Fang's undergraduate thesis  
       "Software Model Checking with Path and Procedure Summaries", Princeton, 2023. 

--- a/srk/src/transition.mli
+++ b/srk/src/transition.mli
@@ -114,6 +114,18 @@ module Make
                                              | `Invalid
                                              | `Unknown ]
 
+  (** Extrapolation operation as defined in Ruijie Fang's undergraduate thesis  
+      "Software Model Checking with Path and Procedure Summaries", Princeton, 2023. 
+      Given 3 transition formulas t1, t2, t3, such that [t1 * t2 * t3] is SAT, 
+      [extrapolate t1 t2 t3] returns a pair of state formulas (p, q) such that
+      (1) p[X'/X] |=  (exists X. t1)
+      (2) (exists X. p(X) /\ t2(X, X'))[X/X'] /\ q is SAT 
+      (3) q |= (exists X'. t2(X, X')  
+      The actual implementation of extrapolation uses model-based projection in srk. *)
+  val extrapolate : ?solver:(C.t Smt.Solver.t) -> t -> t -> t -> [ `Sat of (C.t formula * C.t formula ) 
+                                                                 | `Unsat ]
+
+
   (** Given a pre-condition [P], a path [path], and a post-condition [Q],
       determine whether the Hoare triple [{P}path{Q}] is valid. *)
   val valid_triple : C.t formula -> t list -> C.t formula -> [ `Valid

--- a/srk/test/test_transition.ml
+++ b/srk/test/test_transition.ml
@@ -337,6 +337,7 @@ let negative_eigenvalue () =
   let post = mk_leq srk k n in
   assert_post tr post
 
+(* aux procedure for checking extrapolate results. TODO: stricter checking *)
 let check_extrapolate test_name tr1 tr2 tr3 = 
   match T.extrapolate tr1 tr2 tr3 with 
       | `Sat (f1, f2) -> 

--- a/srk/test/test_transition.ml
+++ b/srk/test/test_transition.ml
@@ -40,7 +40,8 @@ let () =
   V.register_var "n" `TyInt;
   V.register_var "x" `TyInt;
   V.register_var "y" `TyInt;
-  V.register_var "z" `TyInt
+  V.register_var "z" `TyInt;
+  V.register_var "w" `TyInt
 
 let x = Ctx.mk_const (V.symbol_of "x")
 let y = Ctx.mk_const (V.symbol_of "y")
@@ -49,6 +50,7 @@ let i = Ctx.mk_const (V.symbol_of "i")
 let j = Ctx.mk_const (V.symbol_of "j")
 let k = Ctx.mk_const (V.symbol_of "k")
 let n = Ctx.mk_const (V.symbol_of "n")
+let w = Ctx.mk_const (V.symbol_of "w")
 
 let assert_post tr phi =
   let not_post =

--- a/srk/test/test_transition.ml
+++ b/srk/test/test_transition.ml
@@ -429,6 +429,108 @@ let extrapolate3 () =
     ]
   in check_extrapolate "extrapolate3" tr1 tr2 tr3
 
+(** helper methods for checking `Transition.interpolate_or_get_model` *)
+
+let check_model test_name m expected_cnt expected_valuations = 
+  let fail s = 
+    assert_failure @@
+      Printf.sprintf "check_model error: test %s: %s\n" test_name s in 
+  let e = Interpretation.enum m in 
+  if BatEnum.count e < expected_cnt then 
+    let m_str = Format.asprintf "%a" Interpretation.pp m in 
+    fail @@
+      Printf.sprintf "expected %d entires in model but got %d\nmodel:%s\n" 
+        expected_cnt (BatEnum.count e) m_str 
+  else   
+    BatEnum.iter  
+      (fun (sym, v) ->
+        match Hashtbl.find_opt expected_valuations sym with 
+        | Some (predicate, expected) -> 
+          begin match v with 
+          | `Real r -> 
+            if not @@ predicate (Q.to_float r) then 
+              fail @@
+                Printf.sprintf "symbol %s, expected value %s but got %f\n"
+                  (Syntax.show_symbol srk sym) expected (Q.to_float r)
+          | `Bool _ | `Fun _ -> 
+              fail @@ 
+                Printf.sprintf "symbol %s, unknown value\n"
+                  (Syntax.show_symbol srk sym) 
+          end
+        | None -> (** we currently allow havoc symbols in returned models*) ()) e
+
+let form_valuation l = 
+  let tbl = Hashtbl.create 991 in 
+  List.iter (fun (k,v) -> Hashtbl.add tbl k v) l; 
+  tbl 
+
+(** tests for checking `Transition.interpolate_or_get_model` *)
+
+let interpolate_fail () = 
+  let path = 
+    let open Infix in
+    [T.assign "x" (int 0);
+      T.assign "y" (int 0);
+      T.assign "z" (int 999);
+      T.assign "y" (z + (int 1));
+      T.assign "y" (int 0);
+      T.assign "y" (y + (int 1));
+      T.assign "x" (x + (int 1));
+      T.assign "y" (y - (int 1));
+      T.assign "x" y;
+      T.assume ((int 0) <= x);
+      T.assume ((int 0) <= y)
+    ]
+  in
+  let post = let open Infix in mk_not srk ((int 0) <= x) in 
+  begin match T.interpolate_or_concrete_model path post with 
+  | `Invalid m -> 
+    check_model "interpolate_fail" m 3 
+      (form_valuation 
+        [(V.symbol_of "x", ((fun x -> x = 0.0), "0"));
+          (V.symbol_of "y", ((fun y -> y = 0.0), "0"));
+          (V.symbol_of "z", ((fun z -> z = 999.0), "999"))])
+  | _ ->  
+    assert_failure "interpolate_fail: got interpolant when should be sat" 
+  end 
+  
+
+let interpolate_fail1 () = 
+    let path = 
+      let open Infix in 
+      [T.havoc ["x"]; 
+        T.assign "y" ((int 10) + x); 
+        T.assign "z" ((int 100));
+        T.assign "y" ((int 10) + z);
+
+        T.assume ((int 0) < y)] 
+    in let post = let open Infix in Syntax.mk_not srk ((int 100) <= y) in 
+    match T.interpolate_or_concrete_model path post with 
+    | `Invalid m -> 
+      check_model "interpolate_fail1" m 3 
+        (form_valuation 
+          [(V.symbol_of "x"), ((fun x -> x = 0.0), "0");
+            (V.symbol_of "y"), ((fun y -> y = 110.0), "110");
+            (V.symbol_of "z"), ((fun z -> z = 100.0), "100")])
+    | _ -> 
+      assert_failure "interpolate_fail1: got interpolant when should be sat"
+
+let interpolate_fail2 () = 
+    let prefix = [T.havoc ["x"] ] 
+    in let suffix =
+      let open Infix in 
+        T.mul (T.assume ((int 10) < x)) (T.assign "x" ((int 10) + x))
+    in let post =
+      let open Infix in
+        T.guard (T.mul suffix (T.assume ((int 1000) < x))) |> Syntax.mk_not srk 
+    in match T.interpolate_or_concrete_model prefix post with 
+    | `Invalid m -> 
+      check_model "interpolate_fail2" m 1 
+        (form_valuation [V.symbol_of "x", ((fun x -> x > 990.0), "value greater than 990")])
+    | _ -> 
+      assert_failure "interpolate_fail1: got interpolant when should be sat"
+  
+
 
 let suite = "Transition" >::: [
     "degree1" >:: degree1;
@@ -446,4 +548,7 @@ let suite = "Transition" >::: [
     "extrapolate1" >:: extrapolate1;
     "extrapolate2" >:: extrapolate2;
     "extrapolate3" >:: extrapolate3;
+    "interpolate_fail" >:: interpolate_fail;
+    "interpolate_fail1" >:: interpolate_fail1;
+    "interpolate_fail2" >:: interpolate_fail2;
   ]


### PR DESCRIPTION
 - add `Transition.extrapolate` for extrapolation in `srk`
 - refactor `interpolate` code in preparation for adding `interpolate_or_model`
 - add optional argument for accepting a `solver` object in various places (srkZ3, Smt, Quantifier modules) in order to save memory when possible.
 