### PR TITLE
Add floor-mod-div elimination to Nonlinear.linearize

### DIFF
--- a/duet/cra.ml
+++ b/duet/cra.ml
@@ -923,7 +923,7 @@ let preimage transition formula =
          mk_const srk sym
     | None -> fresh_skolem sym
   in
-  mk_and srk [SrkSimplify.eliminate_floor srk (K.guard transition);
+  mk_and srk [K.guard transition;
               substitute_const srk subst formula]
 
 (* Attractor region analysis *)

--- a/srk/src/nonlinear.ml
+++ b/srk/src/nonlinear.ml
@@ -393,7 +393,11 @@ let linearize srk phi =
         in
         List.map (mk_eq srk (mk_real srk QQ.zero)) hull |> mk_and srk
       in
-      mk_and srk [lin_phi; bounds; nonlinear_eqs]
+      mk_and srk [
+        Syntax.eliminate_floor_mod_div srk lin_phi;
+        bounds;
+        nonlinear_eqs
+      ]
     | `Unsat -> mk_false srk
     | `Unknown ->
       logf ~level:`warn "linearize: optimization failed";

--- a/srk/src/nonlinear.mli
+++ b/srk/src/nonlinear.mli
@@ -30,7 +30,11 @@ val uninterpret : 'a context -> ('a,'b) expr -> ('a,'b) expr
 (** Replace non-linear uninterpreted functions with interpreted ones. *)
 val interpret : 'a context -> ('a,'b) expr -> ('a,'b) expr
 
-(** Compute a linear approximation of a non-linear formula. *)
+(** [linearize ctx phi] is a formula whose terms are in the language of
+    linear rational arithmetic, over the symbols of [phi] and possibly new ones,
+    and whose projection onto the symbols of [phi] is an over-approximation of
+    [phi].
+*)
 val linearize : 'a context -> 'a formula -> 'a formula
 
 val mk_log : 'a context -> 'a arith_term -> 'a arith_term -> 'a arith_term

--- a/srk/src/srkSimplify.ml
+++ b/srk/src/srkSimplify.ml
@@ -560,33 +560,6 @@ let simplify_integer_atom srk op s t =
       | _ -> `CompareZero (`Lt, snd (zz_linterm s))
     end
 
-let purify_expr srk filter ?(label=fun _ -> "") =
-  let table = Expr.HT.create 991 in
-  let rewriter srk table =
-    fun expr ->
-    if filter expr then
-      let sym =
-        try
-          Expr.HT.find table expr
-        with Not_found ->
-          let sym = mk_symbol srk ~name:(label expr) (expr_typ srk expr) in
-          Expr.HT.add table expr sym;
-          sym
-      in
-      mk_const srk sym
-    else
-      expr
-  in
-  fun expr ->
-  let expr' = rewrite srk ~up:(rewriter srk table) expr in
-  let map =
-    BatEnum.fold
-      (fun map (term, sym) -> Symbol.Map.add sym term map)
-      Symbol.Map.empty
-      (Expr.HT.enum table)
-  in
-  (expr', map)
-
 let propositionalize srk =
   purify_expr srk (fun expr ->
       match destruct srk expr with

--- a/srk/src/srkSimplify.mli
+++ b/srk/src/srkSimplify.mli
@@ -43,15 +43,6 @@ val simplify_dda : 'a context -> 'a formula -> 'a formula
    division with a dominator less than [max]. *)
 val eliminate_idiv : ?max:int -> 'a context -> 'a formula -> 'a formula
 
-(** Purify floor functions in an expression: replace each function
-   application within a formula with a fresh symbol, and return both
-   the resulting formula [phi] and a mapping [f] from the fresh
-   symbols to terms, so that if we substitute each symbol [s] in the
-   domain of [f] with [floor (f s)], we get the original formula *)
-val purify_floor : 'a context ->
-                   ('a,'b) expr ->
-                   (('a,'b) expr * (('a,typ_arith) expr) Symbol.Map.t)
-
 (** Eliminate floor functions in a formula.  The formula is equivalent
    to the original, modulo the fresh symbols introduced in floor
    purification. *)

--- a/srk/src/syntax.ml
+++ b/srk/src/syntax.ml
@@ -1838,14 +1838,11 @@ let eliminate_floor_mod_div srk phi =
     begin
       match destruct srk expr with
       | `Unop (`Floor, t) ->
-        (* floor(t) --> [s = floor(t)] ; s : Int, s* : Real ; t = s + s* /\ 0 <= s* < 1 *)
-        let fractional_part = mk_symbol srk ~name:"fraction" `TyReal
-                              |> mk_const srk in
-        let integer_part = mk_const srk sym in
-        let sum = mk_add srk [integer_part ; fractional_part] in
-        let lower_bound = mk_leq srk (mk_real srk QQ.zero) fractional_part in
-        let upper_bound = mk_lt srk fractional_part (mk_real srk QQ.one) in
-        [mk_eq srk t sum; lower_bound; upper_bound]
+        (* floor(t) --> [s = floor(t)], iff t - 1 < s <= t /\ Int(s); Int(s) is handled by type of symbol *)
+        let s = mk_const srk sym in
+        let lower_bound = mk_lt srk (mk_sub srk t (mk_int srk 1)) s in
+        let upper_bound = mk_leq srk s t in
+        [mk_and srk [lower_bound; upper_bound]]
       | `Binop (`Mod, s, t) ->
         let quotient = mk_symbol srk ~name:"quotient" `TyInt
                        |> mk_const srk in

--- a/srk/src/syntax.mli
+++ b/srk/src/syntax.mli
@@ -231,7 +231,8 @@ val rewrite : 'a context -> ?down:(('a, 'b) rewriter) -> ?up:(('a, 'b) rewriter)
 val nnf_rewriter : 'a context -> ('a, typ_fo) rewriter
 
 (** Convert to negation normal form ({i down} pass), and eliminate negated
-   arithmetic propositions. *)
+    equalities and inequalities.
+  *)
 val pos_rewriter : 'a context -> ('a, typ_fo) rewriter
 
 module Expr : sig

--- a/srk/src/transitionFormula.mli
+++ b/srk/src/transitionFormula.mli
@@ -53,8 +53,11 @@ val symbolic_constants : 'a t -> Symbol.Set.t
    formula *)
 val wedge_hull : 'a context -> 'a t -> 'a Wedge.t
 
-(** Overapproxmate a transition formula by a linear arithmetic
-   transition formula *)
+(** [linearize ctx phi] is a transition formula 
+    whose terms are in the language of linear rational arithmetic 
+    over the symbols and constants in [phi] and possibly some new ones, and
+    whose projection onto the symbols of [phi] is an over-approximation of [phi].
+*)
 val linearize : 'a context -> 'a t -> 'a t
 
 (** Map pre-state symbols to their post-state counterparts *)

--- a/srk/src/transitionFormula.mli
+++ b/srk/src/transitionFormula.mli
@@ -53,10 +53,10 @@ val symbolic_constants : 'a t -> Symbol.Set.t
    formula *)
 val wedge_hull : 'a context -> 'a t -> 'a Wedge.t
 
-(** [linearize ctx phi] is a transition formula 
-    whose terms are in the language of linear rational arithmetic 
-    over the symbols and constants in [phi] and possibly some new ones, and
-    whose projection onto the symbols of [phi] is an over-approximation of [phi].
+(** [linearize ctx phi] is a transition formula whose terms are in the language 
+   of linear rational arithmetic over the symbols and constants in [phi] and 
+   possibly some new ones, and whose projection onto the symbols of [phi] is an 
+   over-approximation of [phi]. 
 *)
 val linearize : 'a context -> 'a t -> 'a t
 


### PR DESCRIPTION
Per the title, Nonlinear.linearize eliminates floor-mod-div from formulas in addition to purifying other non-linear operations. New symbols, some with integer type, are introduced, and the projection onto the original symbols gives an over-approximation of the input formula.

This change is transparent to clients, and the next PR or two will simplify clients (e.g., `terminationDTA`) to exploit this simplification.