### PR TITLE
Add support for Spacer solver as a separate CHC solver interface

### DIFF
--- a/srk/src/smt.ml
+++ b/srk/src/smt.ml
@@ -139,6 +139,33 @@ module Solver = struct
       { s_add ; s_check ; s_get_model; s_push; s_pop }
 end
 
+(* A generic interface representing a CHC solver.
+
+   This module is implemented by SrkZ3.FixedpointChc, which wraps around
+   Z3's Spacer API. Note that for now, CHC solving is Z3-backed regardless
+   of theory (there is no LIRR CHC backend). *)
+module ChcSolver = struct
+  type 'a t = 'a SrkZ3.FixedpointChc.t
+  type query_status = SrkZ3.FixedpointChc.query_status
+  type 'a relation_fact = 'a SrkZ3.FixedpointChc.relation_fact
+  type 'a step = 'a SrkZ3.FixedpointChc.step
+  type 'a query_answer = 'a SrkZ3.FixedpointChc.query_answer
+
+  let make ?context srk = SrkZ3.FixedpointChc.mk_solver ?context srk
+  let mk_relation = SrkZ3.FixedpointChc.mk_relation
+  let register_relation = SrkZ3.FixedpointChc.register_relation
+  let add_rule = SrkZ3.FixedpointChc.add_rule
+  let add = SrkZ3.FixedpointChc.add
+  let error_relation = SrkZ3.FixedpointChc.error_relation
+  let query_relation = SrkZ3.FixedpointChc.query_relation
+  let get_solution = SrkZ3.FixedpointChc.get_solution
+  let pp_rules = SrkZ3.FixedpointChc.pp_rules
+  let pp_fact = SrkZ3.FixedpointChc.pp_fact
+  let pp_step = SrkZ3.FixedpointChc.pp_step
+  let pp_derivation = SrkZ3.FixedpointChc.pp_derivation
+  let to_string = SrkZ3.FixedpointChc.to_string
+end
+
 let is_sat srk phi =
   let solver = Solver.make srk in
   Solver.add solver [phi];

--- a/srk/src/smt.mli
+++ b/srk/src/smt.mli
@@ -43,6 +43,39 @@ module Solver : sig
   val pop : 'a t -> int -> unit
 end
 
+(** Constrained Horn clause solving via Z3's Fixedpoint interface (Spacer),
+    with refutation-witness extraction.  This is a thin wrapper around
+    {!SrkZ3.FixedpointChc} -- see that module's documentation for the CHC
+    conventions (relations are [`TyFun (_, `TyBool)] symbols; rules are
+    formulas over constants; bodies must be positive) and for the record
+    fields of {!SrkZ3.FixedpointChc.query_answer} /
+    {!SrkZ3.FixedpointChc.step}.
+
+    Note: CHC solving is Z3-backed regardless of the context's theory
+    (unlike {!Solver.make}, there is no LIRR backend). *)
+module ChcSolver : sig
+  type 'a t
+  type query_status = SrkZ3.FixedpointChc.query_status
+  type 'a relation_fact = 'a SrkZ3.FixedpointChc.relation_fact
+  type 'a step = 'a SrkZ3.FixedpointChc.step
+  type 'a query_answer = 'a SrkZ3.FixedpointChc.query_answer
+
+  val make : ?context:SrkZ3.z3_context -> 'a context -> 'a t
+  val mk_relation : 'a t -> ?name:string -> typ_fo list -> symbol
+  val register_relation : 'a t -> symbol -> unit
+  val add_rule : 'a t -> ?name:string -> ?vars:symbol list ->
+    body:'a formula -> head:'a formula -> unit -> unit
+  val add : 'a t -> 'a formula list -> unit
+  val error_relation : 'a t -> symbol
+  val query_relation : 'a t -> symbol -> 'a query_answer
+  val get_solution : 'a t -> symbol -> 'a formula
+  val pp_rules : Format.formatter -> 'a t -> unit
+  val pp_fact : 'a t -> Format.formatter -> 'a relation_fact -> unit
+  val pp_step : 'a t -> Format.formatter -> 'a step -> unit
+  val pp_derivation : 'a t -> Format.formatter -> 'a step list -> unit
+  val to_string : 'a t -> string
+end
+
 (** Compute a model of a formula.  The model is abstract -- it can be used to
     evaluate terms, but its bindings may not be enumerated (see
     [Interpretation] for more detail). *)

--- a/srk/src/srkZ3.ml
+++ b/srk/src/srkZ3.ml
@@ -191,15 +191,27 @@ let mk_quantified ctx qt ?name:(name="_") typ phi =
 
 let z3_of_symbol z3 sym = Z3.Symbol.mk_int z3 (int_of_symbol sym)
 
+(* retrieve the Z3 declaration of a srk symbol *)
 let decl_of_symbol z3 srk sym =
   let (param_sorts, return_sort) = match typ_symbol srk sym with
     | `TyInt | `TyReal | `TyBool | `TyArr ->
       invalid_arg "decl_of_symbol: not a function symbol"
-    | `TyFun (params, return) ->
+    | `TyFun (params, return) -> (* function symbols are, e.g. spacer relations *)
       (List.map (sort_of_typ z3) params, sort_of_typ z3 return)
   in
   let z3sym = z3_of_symbol z3 sym in
   Z3.FuncDecl.mk_func_decl z3 z3sym param_sorts return_sort
+
+(* Z3 constant corresponding to a non-function srk symbol.  The Z3-side name
+   is an int symbol carrying the srk symbol id (see z3_of_symbol) *)
+let z3_const_of_symbol srk z3 sym =
+  match typ_symbol srk sym with
+  | `TyInt | `TyReal | `TyBool | `TyArr as typ ->
+    let decl =
+      Z3.FuncDecl.mk_const_decl z3 (z3_of_symbol z3 sym) (sort_of_typ z3 typ)
+    in
+    Z3.Expr.mk_const_f z3 decl
+  | `TyFun _ -> invalid_arg "z3_const_of_symbol: not a first-order symbol"
 
 let rec z3_of_expr srk z3 expr =
   match Expr.refine_coarse srk expr with
@@ -469,17 +481,9 @@ module Solver = struct
 
 
   let expr_of_sym srk z3 symbol =
-    let sort =
-      match typ_symbol srk symbol with
-      | `TyReal -> sort_of_typ z3 `TyReal
-      | `TyInt -> sort_of_typ z3 `TyInt
-      | `TyBool -> sort_of_typ z3 `TyBool
-      | _ -> assert false
-    in
-    let decl =
-      Z3.FuncDecl.mk_const_decl z3 (z3_of_symbol z3 symbol) sort
-    in
-    Z3.Expr.mk_const_f z3 decl
+    match typ_symbol srk symbol with
+    | `TyReal | `TyInt | `TyBool -> z3_const_of_symbol srk z3 symbol
+    | _ -> assert false
 
   let model_get_value srk z3 m sym =
     match typ_symbol srk sym with
@@ -829,6 +833,884 @@ module CHC = struct
       | None -> assert false
     else
       mk_false srk
+
+  let to_string solver = Z3.Fixedpoint.to_string solver.fp
+end
+
+(** CHC solving via Z3's Spacer Fixpoint engine.
+    Note that this module is separate from the [CHC] module above 
+    
+    - In this module, both positive and negative results comes with artifacts:
+      ([`Reachable]/[`Unreachable]/[`Unknown]). In case of a [`Reachable] answer,
+      the solver returns a derivation tree representing the counterexample trace.
+      In case of a [`Unreachable] answer, the solver returns a valuation for each
+      relation symbol. The valuation is inductive w.r.t. that symbol. Each valuation
+      is de Bruijn-encoded.
+    - In this module, rules are specified as srk formulas over constant symbols and
+      relation symbols, which are represented as srk functions to bool. 
+      The caller must specify which symbols get universally quantified via
+      [Z3.Quantifier.mk_forall_const].  
+    - On a [`Reachable] answer, our code performs a traversal of the Spacer 
+      refutation proof, which manifests as a tree of "hyper-resolution" steps.
+      We then reconstruct a derivation of the counterexample by valuing the 
+      relation's universally quantified variables in the proof tree.
+       - we decide which symbols are relations are recognized by 
+         looking them up in a table
+       - for each derivation step, we construct a SMT query to value all 
+         universally quantified variables in the rule through srk's SMT solver
+         interface ([Solver], i.e. [Smt.StdSolver])
+    - this solver reuses the default Z3 context via [get_default_context ()]
+  *)
+module FixedpointChc = struct
+  type query_status = [ 
+        `Reachable               (* represents a CHC query without a model but with a counterexample *)
+      | `Unreachable             (* represents a CHC query with a model *)
+      | `Unknown of string ]     (* represents a spacer failure *)
+
+  (* A ground relation. Each ground relation is a symbol that is interpreted by a ground formula. *)
+  type 'a relation_fact = {
+    relation : symbol option;
+    fact_args : (('a, typ_fo) expr) list;
+    fact_raw : z3_expr;
+  }
+
+  (* A step in the derivation tree for CHC counterexamples. *)
+  type 'a step = {
+    step_index : int;                                 (* Position of the node in the trace *)
+    rule_name : string option;                        (* Node name of the derivation tree *)
+    conclusion : 'a relation_fact;                    (* The conclusion of the derivation step *)
+    premises : 'a relation_fact list;                 (* The premises of the derivation step *)
+    valuation : (symbol * ('a, typ_fo) expr) list;    (* The valuation of the universally quantified variables in the rule *)
+    step_raw_rule : z3_expr;                          (* The raw rule in Z3 AST form *)
+    step_status : [ `Ok | `Failed of string ];
+  }
+
+  type 'a query_answer = {
+    status : query_status;
+    raw_answer : z3_expr option;
+    steps : 'a step list;
+  }
+
+  (* Metadata we associate with every rule at [add_rule] time.  The witness
+     extractor replays proof steps against this stored (srk-level) copy of
+     the rule, because the copy of the rule inside Z3's proof term is
+     possibly rewritten by Z3 and would hav eits bound variables renamed, 
+     so it cannot be used to recover srk symbol identities. *)
+  type 'a rule_metadata = {
+    rm_name : string option;
+    rm_vars : symbol list;         (* quantified symbols, in binder order *)
+    rm_body : 'a formula;          (* srk body, over constant symbols *)
+    rm_head : 'a formula;          (* srk head atom, over constant symbols *)
+    rm_head_rel : symbol;
+    rm_body_rels : symbol list;    (* body relation multiset, sorted *)
+    rm_z3 : z3_expr;               (* exact AST given to Z3 (id fast path) *)
+  }
+
+  (* representation of the Spacer solver object. *)
+  type 'a solver = {
+    srk : 'a context;
+    z3 : z3_context;
+    fp : Z3.Fixedpoint.fixedpoint;
+    error : symbol;                          (* error() => false is the goal clause *)
+    mutable relations : Symbol.Set.t;        (* collection of all registered relation symbols *)
+    (* Z3 FuncDecl id -> srk relation symbol mapping.  
+       We translate srk Functions to Z3 FuncDecls and we use this to maintain mapping info. *)
+    decl_table : (int, symbol) Hashtbl.t;
+    mutable rules : 'a rule_metadata list;       (* [rules] is a stack maintained in reverse insertion order *)
+    mutable queried : bool;                      (* rules are frozen after the first query *)
+  }
+
+  type 'a t = 'a solver
+
+  let register_relation solver rel =
+    (match typ_symbol solver.srk rel with
+     | `TyFun (_, `TyBool) -> ()
+     | _ ->
+       invalid_arg
+         (Printf.sprintf
+            "FixedpointChc.register_relation: cannot handle term : %s is not a relation \
+             (expected type `TyFun (_, `TyBool))"
+            (show_symbol solver.srk rel)));
+    let decl = decl_of_symbol solver.z3 solver.srk rel in
+    Z3.Fixedpoint.register_relation solver.fp decl;
+    Hashtbl.replace solver.decl_table (Z3.FuncDecl.get_id decl) rel;
+    solver.relations <- Symbol.Set.add rel solver.relations
+
+  let mk_relation solver ?(name="R") dom =
+    let rel = mk_symbol solver.srk ~name (`TyFun (dom, `TyBool)) in
+    register_relation solver rel;
+    rel
+
+  let mk_solver ?(context=get_default_context ()) srk =
+    let fp = Z3.Fixedpoint.mk_fixedpoint context in
+    (* It's pretty important to ensure Spacer does not mutate the CHC relations
+       so that we know what the relations look like during proof reconstruction.
+       
+       The arguments below try to disable a bunch of transformations
+      on the input CHCs Z3 would be doing by default.
+
+        - Disable the xform.* argument settings below stop Z3
+       from slicing/inlining the rules before solving, making the resultant
+       Z3 output parsable.
+
+        - Disable tail_simplifier_pve which propagates variable equalities rules.
+       leaving it enabled results in Z3 inlining small non-recursive systems into
+       a single asserted query fact, which destroys the derivation. 
+       
+        - Disable subsumption_checker which also does inling of CHC rules for certain
+        inputs. *)
+    let params = Z3.Params.mk_params context in
+    let sym x = Z3.Symbol.mk_string context x in
+    Z3.Params.add_symbol params (sym "engine") (sym "spacer");
+    Z3.Params.add_bool params (sym "xform.slice") false;
+    Z3.Params.add_bool params (sym "xform.inline_linear") false;
+    Z3.Params.add_bool params (sym "xform.inline_eager") false;
+    Z3.Params.add_bool params (sym "xform.tail_simplifier_pve") false;
+    Z3.Params.add_bool params (sym "xform.subsumption_checker") false;
+    Z3.Fixedpoint.set_parameters fp params;
+    (* distinguished error node *)
+    let error = mk_symbol srk ~name:"chc_error" (`TyFun ([], `TyBool)) in
+    let solver =
+      { srk; z3 = context; fp; error;
+        relations = Symbol.Set.empty;
+        decl_table = Hashtbl.create 991;
+        rules = [];
+        queried = false }
+    in
+    register_relation solver error;
+    solver
+
+  let error_relation solver = solver.error
+
+  let destruct_relation_application solver phi =
+    match destruct solver.srk phi with
+    | `App (rel, args) when Symbol.Set.mem rel solver.relations ->
+      Some (rel, args)
+    | _ -> None
+
+  let is_relation_application solver phi =
+    match destruct_relation_application solver phi with
+    | Some _ -> true
+    | None -> false
+
+  (* Flatten nested conjunctions into a conjunct list ([true] vanishes). *)
+  let rec flatten_nested_conjuncts srk phi acc =
+    match Formula.destruct srk phi with
+    | `And phis -> List.fold_right (fun c acc -> flatten_nested_conjuncts srk c acc) phis acc
+    | `Tru -> acc
+    | _ -> phi :: acc
+
+  (* Split the body of a Horn clause rule into (relation applications, phi), where 
+      phi is free of any relation symbols.  *)
+  let split_body solver body =
+    let atoms, pure =
+      List.partition (is_relation_application solver) (flatten_nested_conjuncts solver.srk body [])
+    in
+    (atoms, pure)
+
+  (* Type-check application of a relation symbol to make sure the call is well-typed. *)
+  let typecheck_relation_application solver atom =
+    match destruct_relation_application solver atom with
+    | None -> assert false
+    | Some (rel, args) ->
+      let dom = match typ_symbol solver.srk rel with
+        | `TyFun (dom, `TyBool) -> dom
+        | _ -> assert false      (* guaranteed by register_relation *)
+      in
+      if List.length dom <> List.length args then
+        invalid_arg
+          (Printf.sprintf
+             "FixedpointChc: relation symbol %s expects %d arguments but is \
+              applied to %d arguments"
+             (show_symbol solver.srk rel)
+             (List.length dom)
+             (List.length args));
+      List.iter2 (fun expected arg ->
+          let actual = expr_typ solver.srk arg in
+          if actual <> (expected :> typ) then
+            invalid_arg
+              (Printf.sprintf
+                 "FixedpointChc: ill-sorted argument to relation symbol %s"
+                 (show_symbol solver.srk rel)))
+        dom args
+
+  (* A symbol may be universally quantified in a rule if it is a
+     a constant that is not a registered relation.  *)
+  let quantifiable solver s =
+    not (Symbol.Set.mem s solver.relations)
+    && (match typ_symbol solver.srk s with
+        | `TyInt | `TyReal | `TyBool | `TyArr -> true
+        | `TyFun _ -> false)
+
+  (* Detect free variables to form the rule's quantified symbols list *)
+  let quantified_vars solver ?vars body head =
+    let occurring =
+      Symbol.Set.filter
+        (quantifiable solver)
+        (Symbol.Set.union (symbols body) (symbols head))
+    in
+    match vars with
+    | None -> Symbol.Set.elements occurring
+    | Some vs ->
+      let seen = ref Symbol.Set.empty in
+      vs |> List.filter (fun s ->
+          if Symbol.Set.mem s !seen then false
+          else begin
+            seen := Symbol.Set.add s !seen;
+            Symbol.Set.mem s occurring
+          end)
+
+  let add_rule solver ?name ?vars ~body ~head () =
+    if solver.queried then
+      invalid_arg "FixedpointChc.add_rule: rules are frozen after a query";
+    let srk = solver.srk in
+    (* Normalize the head.  A head that is not a registered relation atom
+       (including [mk_false]) is routed to the internal error relation:
+       [body => head] becomes [body /\ not head => chc_error()].  This
+       mirrors the convention of the older CHC module and lets callers state
+       queries as [body => false]; query [error_relation solver] to check
+       them. *)
+    let body, head =
+      match destruct_relation_application solver head with
+      | Some _ -> body, head
+      | None ->
+        (mk_and srk [body; mk_not srk head], mk_app srk solver.error [])
+    in
+    match Formula.destruct srk body with
+    | `Fls -> ()   
+    | _ ->
+      let atoms, _ = split_body solver body in
+      List.iter (typecheck_relation_application solver) (head :: atoms);
+      let vars = quantified_vars solver ?vars body head in
+      let z3_matrix =
+        (* A fact rule (body = true) is passed to Z3 as a bare head atom;
+           otherwise as an implication. *)
+        match Formula.destruct srk body with
+        | `Tru -> z3_of_formula srk solver.z3 head
+        | _ ->
+          Z3.Boolean.mk_implies solver.z3
+            (z3_of_formula srk solver.z3 body)
+            (z3_of_formula srk solver.z3 head)
+      in
+      let z3_rule =
+        (* Quantify rule-local symbols by abstracting the corresponding Z3
+           constants.  Z3 rejects empty binder lists, so ground rules skip
+           the quantifier. *)
+        match vars with
+        | [] -> z3_matrix
+        | _ ->
+          Z3.Quantifier.mk_forall_const solver.z3
+            (List.map (z3_const_of_symbol srk solver.z3) vars)
+            z3_matrix
+            None [] [] None None
+          |> Z3.Quantifier.expr_of_quantifier
+      in
+      let z3_name = BatOption.map (Z3.Symbol.mk_string solver.z3) name in
+      Z3.Fixedpoint.add_rule solver.fp z3_rule z3_name;
+      let head_rel = match destruct_relation_application solver head with
+        | Some (rel, _) -> rel
+        | None -> assert false
+      in
+      let body_rels =
+        atoms
+        |> List.map (fun atom ->
+            match destruct_relation_application solver atom with
+            | Some (rel, _) -> rel
+            | None -> assert false)
+        |> List.sort Stdlib.compare
+      in
+      solver.rules <-
+        { rm_name = name; rm_vars = vars; rm_body = body; rm_head = head;
+          rm_head_rel = head_rel; rm_body_rels = body_rels; rm_z3 = z3_rule }
+        :: solver.rules
+
+  let add solver phis =
+    if solver.queried then
+      invalid_arg "FixedpointChc.add: assertions are frozen after a query";
+    Z3.Fixedpoint.add solver.fp
+      (List.map (z3_of_formula solver.srk solver.z3) phis)
+
+
+  module ProofWalk = struct
+    (* The 'step' type represents a hyper-resolution node inside Spacer refutation, 
+       [raw_rule]  : the rule corresponding to this node
+       [raw_conclusion] : the ground fact derived by this node
+       [raw_premises] : the ground facts required as assumptions by this node *)
+    type raw_step = {
+      raw_rule : z3_expr;
+      raw_conclusion : z3_expr;
+      raw_premises : z3_expr list;
+    }
+
+    let split_last xs =
+      match List.rev xs with
+      | [] -> failwith "split_last: empty list"
+      | y :: ys -> (List.rev ys, y)
+
+    let decl_name_opt e =
+      try
+        Some (Z3.Expr.get_func_decl e
+              |> Z3.FuncDecl.get_name
+              |> Z3.Symbol.to_string)
+      with _ -> None
+
+    let is_quantified_expr e = Z3.AST.is_quantifier (Z3.Expr.ast_of_expr e)
+
+    let is_hyper_res_node e =
+      match decl_name_opt e with
+      | Some ("hyper-res" | "hyper-resolve" | "hyper_resolve") -> true
+      | _ -> false
+
+    (* Returns the premises of a proof tree node *)
+    let premises_of (p: z3_expr) =
+      if Z3.Proof.is_modus_ponens p || is_hyper_res_node p then
+        fst (split_last (Z3.Expr.get_args p))
+      else
+        []
+
+    (* The fact established by a proof node *)
+    let proof_fact p =
+      if Z3.Proof.is_asserted p || Z3.Proof.is_goal p
+         || Z3.Proof.is_hypothesis p then
+        match Z3.Expr.get_args p with
+        | [fact] -> fact
+        | _ -> p
+      else if Z3.Proof.is_modus_ponens p || is_hyper_res_node p then
+        snd (split_last (Z3.Expr.get_args p))
+      else
+        p
+
+    let rec flatten_and e =
+      if Z3.Boolean.is_and e then
+        List.concat_map flatten_and (Z3.Expr.get_args e)
+      else
+        [e]
+
+    (* Collect the hyper-resolution nodes of a proof in post-order: 
+        for each step, the premises appear before it, and the conclusions follow it.
+        the resulting list reads as a derivation (leaves first, query last). *)
+    let walk_hyper_res_postorder proof =
+      let seen = Hashtbl.create 31 in
+      let out = ref [] in
+      let rec visit p =
+        let id = Z3.AST.get_id (Z3.Expr.ast_of_expr p) in
+        if not (Hashtbl.mem seen id) then begin
+          Hashtbl.add seen id ();
+          List.iter visit (premises_of p);
+          if is_hyper_res_node p then out := p :: !out
+        end
+      in
+      visit proof;
+      List.rev !out
+
+    let raw_steps proof =
+      walk_hyper_res_postorder proof
+      |> BatList.filter_map (fun hr ->
+          match Z3.Expr.get_args hr with
+          | [] | [_] ->
+            logf ~level:`warn
+              "FixedpointChc: skipping malformed hyper-res node";
+            None
+          | args ->
+            let premise_nodes, conclusion = split_last args in
+            match premise_nodes with
+            | main_rule :: side_proofs ->
+              Some { raw_rule = proof_fact main_rule;
+                     raw_conclusion = conclusion;
+                     raw_premises = List.map proof_fact side_proofs }
+            | [] -> None)
+
+    (* ------------------------------------------------------------ *)
+    (* Z3 fallback valuation
+      RF June 26: The code below is created by Claude Code.
+      When a proof step's rule cannot be matched against any stored rule
+      we have no choice but to extract the result in raw Z3 format.
+      Symbols inside these rules are extracted as Z3's bound-variable names
+      , which cannot be mapped back to srk symbols.                 *)
+    (* ------------------------------------------------------------ *)
+
+    (* Peel the universal prefix of a rule as it appears in the proof. *)
+    let decompose_horn_rule rule =
+      let rec peel names sorts e =
+        if is_quantified_expr e then
+          let q = Z3.Quantifier.quantifier_of_expr e in
+          if Z3.Quantifier.is_universal q then
+            let names' =
+              Z3.Quantifier.get_bound_variable_names q
+              |> List.map Z3.Symbol.to_string
+            in
+            let sorts' = Z3.Quantifier.get_bound_variable_sorts q in
+            peel (names @ names') (sorts @ sorts') (Z3.Quantifier.get_body q)
+          else
+            (names, sorts, e)
+        else
+          (names, sorts, e)
+      in
+      let names, sorts, core = peel [] [] rule in
+      if Z3.Boolean.is_implies core then
+        match Z3.Expr.get_args core with
+        | [body; head] -> (names, sorts, head, flatten_and body)
+        | _ -> (names, sorts, core, [])
+      else
+        (names, sorts, core, [])
+
+    (* At the Z3 level, a relation symbol is a Bool-sorted application of an
+       uninterpreted function declaration.  *)
+    let is_relation_symbol z3 e =
+      (not (is_quantified_expr e))
+      && Z3.Sort.equal (Z3.Expr.get_sort e) (Z3.Boolean.mk_sort z3)
+      && (try
+            Z3.FuncDecl.get_decl_kind (Z3.Expr.get_func_decl e)
+            = Z3enums.OP_UNINTERPRETED
+          with _ -> false)
+
+    let same_relation a b =
+      Z3.FuncDecl.equal (Z3.Expr.get_func_decl a) (Z3.Expr.get_func_decl b)
+      && Z3.Expr.get_num_args a = Z3.Expr.get_num_args b
+
+
+    let instantiate_bound_vars e witnesses =
+      Z3.Expr.substitute_vars e (List.rev witnesses)
+
+    let matchings same relation_symbols facts =
+      let rec go available facts =
+        match facts with
+        | [] -> if available = [] then [[]] else []
+        | f :: rest ->
+          available
+          |> List.concat_map (fun (i, a) ->
+              if same a f then
+                go (List.remove_assoc i available) rest
+                |> List.map (fun m -> (a, f) :: m)
+              else
+                [])
+      in
+      go (List.mapi (fun i a -> (i, a)) relation_symbols) facts
+
+    let solve_step_valuation z3 rule conclusion premises =
+      let names, sorts, head, body_lits = decompose_horn_rule rule in
+      let witnesses =
+        List.mapi
+          (fun i s -> Z3.Expr.mk_fresh_const z3 (Printf.sprintf "__w%d_" i) s)
+          sorts
+      in
+      let head_i = instantiate_bound_vars head witnesses in
+      let body_i = List.map (fun l -> instantiate_bound_vars l witnesses) body_lits in
+      let rel_atoms = List.filter (is_relation_symbol z3) body_i in
+      let pure = List.filter (fun e -> not (is_relation_symbol z3 e)) body_i in
+      let atom_eqs pat grd =
+        (* Constraints forcing an instantiated relation symbol to equal a ground fact:
+           pointwise argument equalities when both are relation atoms of the
+           same declaration; plain equality otherwise. *)
+        if is_relation_symbol z3 pat && is_relation_symbol z3 grd then
+          if not (same_relation pat grd) then None
+          else if Z3.Expr.get_num_args pat = 0 then
+            Some [Z3.Boolean.mk_eq z3 pat grd]
+          else
+            Some (List.map2 (Z3.Boolean.mk_eq z3)
+                    (Z3.Expr.get_args pat) (Z3.Expr.get_args grd))
+        else
+          Some [Z3.Boolean.mk_eq z3 pat grd]
+      in
+      match atom_eqs head_i conclusion with
+      | None -> Error "rule head does not match proof conclusion"
+      | Some head_eqs ->
+        let try_matching pairs =
+          let s = Z3.Solver.mk_simple_solver z3 in
+          try
+            Z3.Solver.add s head_eqs;
+            List.iter (fun (pat, grd) ->
+                match atom_eqs pat grd with
+                | Some cs -> Z3.Solver.add s cs
+                | None -> raise Exit)
+              pairs;
+            Z3.Solver.add s pure;
+            match Z3.Solver.check s [] with
+            | Z3.Solver.SATISFIABLE ->
+              begin match Z3.Solver.get_model s with
+                | None -> None
+                | Some m ->
+                  let value_of w =
+                    match Z3.Model.eval m w true with
+                    | Some v -> Z3.Expr.simplify v None
+                    | None -> w
+                  in
+                  Some (List.map2
+                          (fun nm w -> (nm, Z3.Expr.to_string (value_of w)))
+                          names witnesses)
+              end
+            | _ -> None
+          with Exit -> None
+        in
+        let rec first = function
+          | [] -> Error "no consistent premise matching at the Z3 level"
+          | m :: rest ->
+            match try_matching m with
+            | Some v -> Ok v
+            | None -> first rest
+        in
+        first (matchings same_relation rel_atoms premises)
+  end
+
+  (* ---------------------------------------------------------------- *)
+  (* Witness extraction (srk level)                                   *)
+  (* [RF June 2026: The module below is largely coded with help of
+      Claude Code. The main idea is that we perform a walk of Z3's
+      Spacer proof tree, which consists of many hyper-resolution nodes,
+      and then extract valuations for universally quantified symbols in
+      each proof tree node (which corresponds to a node in counterexample
+      hyper-path).                                                    *)
+  (* ---------------------------------------------------------------- *)
+
+  (* Recognize a declaration appearing in a proof term as one of our
+     registered relations.  Primary key: Z3 FuncDecl id (decls are
+     hash-consed per context).  Fallback: srk symbols become Z3 *int*
+     symbols, so a decl whose name is an int symbol can be decoded
+     directly.  Foreign declarations (e.g. Z3-generated [query!N], whose
+     names are strings) return None -- they must never reach
+     [sym_of_decl], which asserts int-symbol names. *)
+  let lookup_decl solver decl =
+    match Hashtbl.find_opt solver.decl_table (Z3.FuncDecl.get_id decl) with
+    | Some rel -> Some rel
+    | None ->
+      let name = Z3.FuncDecl.get_name decl in
+      if Z3.Symbol.is_int_symbol name then
+        let s = symbol_of_int (Z3.Symbol.get_int name) in
+        if Symbol.Set.mem s solver.relations then Some s else None
+      else
+        None
+
+  (* Convert a ground fact from the proof into srk terms.  Total: any
+     failure (foreign declaration, unconvertible argument, non-application
+     expression) degrades to [relation = None] / [fact_args = []] with the
+     raw Z3 expression preserved. *)
+  let fact_of_z3 solver e =
+    try
+      let decl = Z3.Expr.get_func_decl e in
+      match lookup_decl solver decl with
+      | Some rel ->
+        let fact_args =
+          try List.map (expr_of_z3 solver.srk) (Z3.Expr.get_args e)
+          with _ -> []
+        in
+        { relation = Some rel; fact_args; fact_raw = e }
+      | None -> { relation = None; fact_args = []; fact_raw = e }
+    with _ -> { relation = None; fact_args = []; fact_raw = e }
+
+  (* Type-directed equality between two srk expressions of the same
+     first-order type (used to equate rule-atom arguments with ground fact
+     arguments). *)
+  let mk_eq_typed srk a b =
+    match Expr.refine srk a, Expr.refine srk b with
+    | `ArithTerm a, `ArithTerm b -> mk_eq srk a b
+    | `ArrTerm a, `ArrTerm b -> mk_arr_eq srk a b
+    | `Formula a, `Formula b -> mk_iff srk a b
+    | _, _ -> invalid_arg "FixedpointChc: ill-typed argument equality"
+
+  exception Unconverted
+
+  let fact_rel_args solver fact =
+    match fact.relation with
+    | None -> raise Unconverted
+    | Some rel ->
+      let arity = match typ_symbol solver.srk rel with
+        | `TyFun (dom, _) -> List.length dom
+        | _ -> 0
+      in
+      if List.length fact.fact_args = arity then (rel, fact.fact_args)
+      else raise Unconverted
+
+  (* Solve one derivation step against a candidate stored rule: find values
+     for the rule's quantified symbols under which the rule's head equals
+     the step's conclusion, its body atoms equal the step's premises (for
+     some matching), and its pure constraints hold.  The satisfiability
+     query goes through srk's standard SMT solver interface ([Solver] =
+     [Smt.StdSolver]); using the engine's Z3 context.  On success the
+     valuation is keyed by the rule's own srk symbols. *)
+  let solve_step solver rm conclusion premises =
+    let srk = solver.srk in
+    try
+      let (concl_rel, concl_args) = fact_rel_args solver conclusion in
+      let prems = List.map (fact_rel_args solver) premises in
+      if rm.rm_head_rel <> concl_rel then
+        Error "head relation does not match conclusion"
+      else begin
+        let atoms, pure = split_body solver rm.rm_body in
+        let atom_pairs =
+          List.map (fun atom ->
+              match destruct_relation_application solver atom with
+              | Some p -> p
+              | None -> assert false)
+            atoms
+        in
+        let head_args =
+          match destruct_relation_application solver rm.rm_head with
+          | Some (_, args) -> args
+          | None -> assert false
+        in
+        let head_eqs = List.map2 (mk_eq_typed srk) head_args concl_args in
+        (* Interpretation cannot represent array values, so array-typed
+           symbols are omitted from the model request (and hence from the
+           valuation). *)
+        let model_syms =
+          List.filter (fun s ->
+              match typ_symbol srk s with
+              | `TyArr -> false
+              | _ -> true)
+            rm.rm_vars
+        in
+        let try_matching pairing =
+          let prem_eqs =
+            List.concat_map
+              (fun ((_, atom_args), (_, fact_args)) ->
+                 List.map2 (mk_eq_typed srk) atom_args fact_args)
+              pairing
+          in
+          let phi = mk_and srk (head_eqs @ prem_eqs @ pure) in
+          let aux = Solver.make ~context:solver.z3 srk in
+          Solver.add aux [phi];
+          match Solver.get_concrete_model aux model_syms with
+          | `Sat interp ->
+            Some (model_syms |> List.map (fun s ->
+                let value : ('a, typ_fo) expr =
+                  match Interpretation.value interp s with
+                  | `Real qq -> ((mk_real srk qq) :> ('a, typ_fo) expr)
+                  | `Bool true -> ((mk_true srk) :> ('a, typ_fo) expr)
+                  | `Bool false -> ((mk_false srk) :> ('a, typ_fo) expr)
+                  | `Fun _ -> mk_const srk s   (* not expected for
+                                                  first-order symbols *)
+                in
+                (s, value)))
+          | `Unsat | `Unknown -> None
+        in
+        let same (rel_a, _) (rel_f, _) = rel_a = rel_f in
+        let rec first = function
+          | [] -> Error "no consistent premise matching"
+          | m :: rest ->
+            match try_matching m with
+            | Some v -> Ok v
+            | None -> first rest
+        in
+        first (ProofWalk.matchings same atom_pairs prems)
+      end
+    with Unconverted -> Error "step facts are not convertible to srk"
+
+  (* Candidate stored rules for a proof step: same head relation and same
+     multiset of body relations.  If the proof cites a rule AST that is
+     literally one of ours (Z3 did not rewrite it), that rule is moved to
+     the front. *)
+  let candidate_rules solver raw_rule concl_rel prem_rels =
+    let prem_key = List.sort Stdlib.compare prem_rels in
+    let structural =
+      List.filter
+        (fun rm -> rm.rm_head_rel = concl_rel && rm.rm_body_rels = prem_key)
+        solver.rules
+    in
+    let raw_id = Z3.AST.get_id (Z3.Expr.ast_of_expr raw_rule) in
+    let exact, rest =
+      List.partition
+        (fun rm -> Z3.AST.get_id (Z3.Expr.ast_of_expr rm.rm_z3) = raw_id)
+        structural
+    in
+    exact @ rest
+
+  let extract_steps solver answer =
+    ProofWalk.raw_steps answer
+    |> List.map (fun (rs : ProofWalk.raw_step) ->
+        let conclusion = fact_of_z3 solver rs.ProofWalk.raw_conclusion in
+        let premises =
+          List.map (fact_of_z3 solver) rs.ProofWalk.raw_premises
+        in
+        (* Diagnostic-only fallback: the prototype's Z3-level valuation.
+           Its variable names are Z3's (renamed) bound-variable names, so
+           the result is reported as a string, not as a typed valuation. *)
+        let fallback_message () =
+          match
+            ProofWalk.solve_step_valuation solver.z3
+              rs.ProofWalk.raw_rule
+              rs.ProofWalk.raw_conclusion
+              rs.ProofWalk.raw_premises
+          with
+          | Ok vals ->
+            Printf.sprintf
+              "rule not identified; Z3-level valuation: %s"
+              (String.concat ", "
+                 (List.map (fun (n, v) -> n ^ " = " ^ v) vals))
+          | Error msg ->
+            Printf.sprintf
+              "rule not identified; Z3-level fallback failed: %s" msg
+        in
+        let identified =
+          match conclusion.relation with
+          | None -> None
+          | Some concl_rel ->
+            let prem_rels_opt =
+              try
+                Some (List.map (fun p ->
+                    match p.relation with
+                    | Some r -> r
+                    | None -> raise Unconverted)
+                    premises)
+              with Unconverted -> None
+            in
+            match prem_rels_opt with
+            | None -> None
+            | Some prem_rels ->
+              let rec try_candidates = function
+                | [] -> None
+                | rm :: rest ->
+                  match solve_step solver rm conclusion premises with
+                  | Ok valuation -> Some (rm, valuation)
+                  | Error _ -> try_candidates rest
+              in
+              try_candidates
+                (candidate_rules solver rs.ProofWalk.raw_rule
+                   concl_rel prem_rels)
+        in
+        let rule_name, valuation, step_status =
+          match identified with
+          | Some (rm, valuation) -> (rm.rm_name, valuation, `Ok)
+          | None -> (None, [], `Failed (fallback_message ()))
+        in
+        { step_index = 0; rule_name; conclusion; premises; valuation;
+          step_raw_rule = rs.ProofWalk.raw_rule; step_status })
+    (* Z3 closes the derivation with a synthetic step concluding an
+       internal query relation (e.g. [query!N]) from the queried fact.
+       Steps whose conclusion cannot be mapped to a registered relation
+       carry no client-visible information, so they are dropped from the
+       typed derivation; the raw answer retains them for debugging. *)
+    |> List.filter (fun st ->
+        match st.conclusion.relation with
+        | Some _ -> true
+        | None ->
+          logf ~level:`debug
+            "FixedpointChc: dropping synthetic derivation step %s"
+            (Z3.Expr.to_string st.conclusion.fact_raw);
+          false)
+    |> List.mapi (fun i st -> { st with step_index = i })
+
+  let query_relation solver rel =
+    if not (Symbol.Set.mem rel solver.relations) then
+      invalid_arg "FixedpointChc.query_relation: unregistered relation";
+    solver.queried <- true;
+    let decl = decl_of_symbol solver.z3 solver.srk rel in
+    let status =
+      try
+        (* query_r queries the registered declaration directly; unlike
+           [query] on a formula it does not manufacture an auxiliary
+           [query!N] relation for the goal. *)
+        match Z3.Fixedpoint.query_r solver.fp [decl] with
+        | Z3.Solver.SATISFIABLE -> `Reachable
+        | Z3.Solver.UNSATISFIABLE -> `Unreachable
+        | Z3.Solver.UNKNOWN ->
+          let reason =
+            try Z3.Fixedpoint.get_reason_unknown solver.fp
+            with Z3.Error msg -> msg
+          in
+          `Unknown reason
+      with Z3.Error msg ->
+        logf ~level:`warn "FixedpointChc.query_relation: Z3 error: %s" msg;
+        `Unknown msg
+    in
+    let raw_answer =
+      match status with
+      | `Reachable ->
+        (try Z3.Fixedpoint.get_answer solver.fp with Z3.Error _ -> None)
+      | _ -> None
+    in
+    let steps =
+      match raw_answer with
+      | Some answer ->
+        (try extract_steps solver answer
+         with exn ->
+           logf ~level:`warn
+             "FixedpointChc: witness extraction failed: %s"
+             (Printexc.to_string exn);
+           [])
+      | None -> []
+    in
+    { status; raw_answer; steps }
+
+  let get_solution solver rel =
+    if not (Symbol.Set.mem rel solver.relations) then
+      invalid_arg "FixedpointChc.get_solution: unregistered relation";
+    if List.exists (fun rm -> rm.rm_head_rel = rel) solver.rules then
+      let decl = decl_of_symbol solver.z3 solver.srk rel in
+      match Z3.Fixedpoint.get_cover_delta solver.fp (-1) decl with
+      | Some inv -> formula_of_z3 solver.srk inv
+      | None -> failwith "FixedpointChc.get_solution: no solution available"
+    else
+      (* A relation that heads no rule is empty. *)
+      mk_false solver.srk
+
+  (* Print the CHC system  *)
+  let pp_rules formatter solver =
+    let srk = solver.srk in
+    let pp_rule formatter rm =
+      Format.fprintf formatter "@[<hov 2>";
+      (match rm.rm_name with
+       | Some name -> Format.fprintf formatter "%s: " name
+       | None -> ());
+      (match rm.rm_vars with
+       | [] -> ()
+       | vars ->
+         Format.fprintf formatter "forall %a.@ "
+           (SrkUtil.pp_print_enum_nobox (pp_symbol srk))
+           (BatList.enum vars));
+      Format.fprintf formatter "%a@ => %a@]"
+        (Formula.pp srk) rm.rm_body
+        (Formula.pp srk) rm.rm_head
+    in
+    Format.fprintf formatter "@[<v 0>%a@]"
+      (SrkUtil.pp_print_enum_nobox
+         ~pp_sep:(fun formatter () -> Format.fprintf formatter "@;")
+         pp_rule)
+      (BatList.enum (List.rev solver.rules))
+
+  let pp_fact solver formatter fact =
+    match fact.relation with
+    | Some rel ->
+      Format.fprintf formatter "@[<h>%a(%a)@]"
+        (pp_symbol solver.srk) rel
+        (SrkUtil.pp_print_enum_nobox (Expr.pp solver.srk))
+        (BatList.enum fact.fact_args)
+    | None ->
+      (* Foreign fact (e.g. a Z3-internal relation): show the raw expr. *)
+      Format.pp_print_string formatter (Z3.Expr.to_string fact.fact_raw)
+
+  let pp_step solver formatter step =
+    let srk = solver.srk in
+    Format.fprintf formatter "@[<v 2>step %d" step.step_index;
+    (match step.rule_name with
+     | Some name -> Format.fprintf formatter " [%s]" name
+     | None -> ());
+    Format.fprintf formatter ": %a" (pp_fact solver) step.conclusion;
+    (match step.premises with
+     | [] -> ()
+     | premises ->
+       Format.fprintf formatter "@;<- @[<hov 0>%a@]"
+         (SrkUtil.pp_print_enum_nobox (pp_fact solver))
+         (BatList.enum premises));
+    begin match step.step_status with
+      | `Ok ->
+        if step.valuation <> [] then
+          Format.fprintf formatter "@;with @[<hov 0>%a@]"
+            (SrkUtil.pp_print_enum_nobox
+               (fun formatter (sym, value) ->
+                  Format.fprintf formatter "@[<h>%a = %a@]"
+                    (pp_symbol srk) sym
+                    (Expr.pp srk) value))
+            (BatList.enum step.valuation)
+      | `Failed msg -> Format.fprintf formatter "@;FAILED: %s" msg
+    end;
+    Format.fprintf formatter "@]"
+
+  let pp_derivation solver formatter steps =
+    Format.fprintf formatter "@[<v 0>%a@]"
+      (SrkUtil.pp_print_enum_nobox
+         ~pp_sep:(fun formatter () -> Format.fprintf formatter "@;")
+         (pp_step solver))
+      (BatList.enum steps)
 
   let to_string solver = Z3.Fixedpoint.to_string solver.fp
 end

--- a/srk/src/srkZ3.mli
+++ b/srk/src/srkZ3.mli
@@ -6,6 +6,12 @@ type z3_context = Z3.context
 type z3_expr = Z3.Expr.expr
 type z3_func_decl = Z3.FuncDecl.func_decl
 
+(** The process-global Z3 context.  Every [?context] argument in this module
+    defaults to it.  Z3 ASTs are tied to their context; mixing ASTs from
+    different contexts is an error, so new code should use this context
+    rather than calling [Z3.mk_context]. *)
+val get_default_context : unit -> z3_context
+
 type 'a open_expr = [
   | `Real of QQ.t
   | `App of z3_func_decl * 'a list
@@ -133,4 +139,151 @@ module CHC : sig
   val get_solution : 'a solver -> symbol -> 'a formula
 
   val to_string : 'a solver -> string
+end
+
+(** Constrained Horn clause solving via Z3's Fixedpoint interface (the
+    Spacer engine), with refutation-witness extraction.
+
+    This module is separate from (and unrelated to) the older {!CHC} module
+    above.  A system of CHCs is built from {i relations} and {i rules}:
+
+    - A relation of arity [n] is an srk symbol of type
+      [`TyFun (arg_types, `TyBool)]; an {i atom} is a Bool-typed application
+      [mk_app rel args] (which is an srk formula).  Relations must be
+      registered ({!FixedpointChc.register_relation} /
+      {!FixedpointChc.mk_relation}) before appearing in rules.
+    - A rule [forall vars. body => head] is given as two srk formulas over
+      ordinary {i constant symbols}; the engine quantifies the rule-local
+      symbols itself.  The body must be {i positive}: registered relations
+      may occur only as top-level conjunct atoms.
+
+    Reachability of a relation is decided with {!FixedpointChc.query_relation};
+    on [`Reachable] the answer carries a best-effort typed derivation
+    (see {!FixedpointChc.step}); on [`Unreachable],
+    {!FixedpointChc.get_solution} yields the inductive invariant certificate
+    for each relation. *)
+module FixedpointChc : sig
+
+  (** CHC solver over Z3's Fixedpoint engine. *)
+  type 'a t
+
+  (** Result of a reachability query.  Note the vocabulary: [`Reachable]
+      means the queried relation is non-empty (for an error relation: the
+      program is {i unsafe}); [`Unreachable] means the CHC system has a
+      solution in which the queried relation is empty (the program is
+      {i safe}). *)
+  type query_status = [ `Reachable | `Unreachable | `Unknown of string ]
+
+  (** A ground relation fact appearing in a derivation, e.g. [R(0, 5)].
+      [relation = None] means the fact's declaration is foreign (e.g. a
+      Z3-generated auxiliary relation) and could not be mapped back to a
+      registered srk relation; [fact_raw] is always the original Z3
+      expression. *)
+  type 'a relation_fact = {
+    relation : symbol option;
+    fact_args : (('a, typ_fo) expr) list;  (** [[]] if conversion failed *)
+    fact_raw : z3_expr;
+  }
+
+  (** One hyper-resolution step of a refutation, i.e. one rule application
+      in the derivation of the queried relation.  Steps are listed in
+      derivation order: premises of a step are concluded by earlier steps.
+
+      [conclusion] and [premises] are the reliable payload: they are ground
+      facts whose relation declarations are ours.  [rule_name]/[valuation]
+      are best-effort: they are populated when the step could be matched
+      against a stored rule ([step_status = `Ok]), in which case [valuation]
+      assigns a ground value to each of the rule's quantified symbols
+      (array-typed symbols omitted).  When no stored rule matches,
+      [step_status] is [`Failed reason] and the facts are still usable. *)
+  type 'a step = {
+    step_index : int;
+    rule_name : string option;
+    conclusion : 'a relation_fact;
+    premises : 'a relation_fact list;
+    valuation : (symbol * ('a, typ_fo) expr) list;
+    step_raw_rule : z3_expr;
+    step_status : [ `Ok | `Failed of string ];
+  }
+
+  type 'a query_answer = {
+    status : query_status;
+    raw_answer : z3_expr option;
+    (** [Z3.Fixedpoint.get_answer], captured immediately after the query
+        (Z3 keeps only the most recent answer). *)
+    steps : 'a step list;
+    (** Nonempty only for [`Reachable]; best effort, [[]] if the proof
+        could not be walked. *)
+  }
+
+  (** Create a CHC solver.  Configures the Spacer engine and disables the
+      slicing/inlining preprocessing passes (so refutation proofs cite
+      rules recognizably close to the ones added). *)
+  val mk_solver : ?context:z3_context -> 'a context -> 'a t
+
+  (** [mk_relation solver ~name dom] creates a fresh symbol of type
+      [`TyFun (dom, `TyBool)] and registers it as a relation. *)
+  val mk_relation : 'a t -> ?name:string -> typ_fo list -> symbol
+
+  (** Register an existing symbol of type [`TyFun (_, `TyBool)] as a
+      relation.  Raises [Invalid_argument] on any other type. *)
+  val register_relation : 'a t -> symbol -> unit
+
+  (** [add_rule solver ~name ~vars ~body ~head ()] adds the rule
+      [forall vars. body => head].
+
+      [head] must be an application of a registered relation; any other
+      head [h] (e.g. [mk_false srk]) is routed to the internal error
+      relation, turning the rule into
+      [body /\ not h => error_relation solver ()].
+
+      [vars] lists the rule-local (universally quantified) symbols --
+      typically pre-state, post-state and havoc symbols.  It is sanitized
+      (deduplicated; restricted to first-order non-relation symbols that
+      occur in the rule).  If omitted, it is inferred as {i all} such
+      symbols, in symbol-id order; callers that know the intended variable
+      set should pass it explicitly.
+
+      Raises [Invalid_argument] if the body is not a positive Horn body
+      (a registered relation occurring under negation/disjunction/ite or
+      inside an atom argument), if an atom is ill-sorted w.r.t. its
+      relation's declared domain, or if a query has already been issued. *)
+  val add_rule : 'a t -> ?name:string -> ?vars:symbol list ->
+    body:'a formula -> head:'a formula -> unit -> unit
+
+  (** Assert background (non-CHC) facts. *)
+  val add : 'a t -> 'a formula list -> unit
+
+  (** The internal nullary relation concluded by rules whose head is not a
+      registered relation atom (see {!add_rule}).  Query this symbol to
+      check [body => false]-style rules. *)
+  val error_relation : 'a t -> symbol
+
+  (** Decide reachability of a registered relation.  Rules are frozen after
+      the first query; multiple relations may be queried in sequence. *)
+  val query_relation : 'a t -> symbol -> 'a query_answer
+
+  (** After an [`Unreachable] query: the inductive-invariant certificate
+      that Spacer computed for [rel], as a formula in which de Bruijn
+      variable [i] refers to [rel]'s [i]-th argument.  Returns [mk_false]
+      for relations that head no rule. *)
+  val get_solution : 'a t -> symbol -> 'a formula
+
+  (** Print the registered CHC system in srk syntax (one rule per line,
+      with the caller's symbol names).  More readable than {!to_string},
+      which shows Z3's internal rendering. *)
+  val pp_rules : Format.formatter -> 'a t -> unit
+
+  (** Print a ground relation fact, e.g. [p(101, 91)]; foreign facts are
+      shown as their raw Z3 expression. *)
+  val pp_fact : 'a t -> Format.formatter -> 'a relation_fact -> unit
+
+  (** Print one derivation step: index, rule name (if identified),
+      conclusion, premises, and valuation (or failure reason). *)
+  val pp_step : 'a t -> Format.formatter -> 'a step -> unit
+
+  (** Print a derivation, one step per line, in derivation order. *)
+  val pp_derivation : 'a t -> Format.formatter -> 'a step list -> unit
+
+  val to_string : 'a t -> string
 end


### PR DESCRIPTION
Support for CHC solving via Spacer in `srk`. 

 - Relation symbols are represented as srk functions that map to bool.
 - If a CHC system has a model, we use it to construct formulas that interpret each relation symbol.
 - Otherwise, we walk an extracted counterexample trace in terms of Z3's hyper-res proof tree format to extract a counterexample.